### PR TITLE
Feature:hb-57-user-story-creating-methods-like-set-and-get-protocol-fee-handler

### DIFF
--- a/contracts/cosmwasm-vm/libraries/Cargo.toml
+++ b/contracts/cosmwasm-vm/libraries/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "libraries"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cw-storage-plus = "1.0.1"
+cosmwasm-std = "1.1.3"
+cosmwasm = "0.7.2"

--- a/contracts/cosmwasm-vm/libraries/src/fees.rs
+++ b/contracts/cosmwasm-vm/libraries/src/fees.rs
@@ -1,0 +1,149 @@
+use std::{collections::btree_map::Values, error::Error};
+
+
+use cosmwasm_std::{Deps, DepsMut, StdResult};
+use cw_storage_plus::{Key, Map};
+
+type Account = String;
+
+#[derive(Debug)]
+pub struct Fees<'a>(Map<'a, Account, u128>);
+
+impl Fees<'_> {
+    pub fn new() -> Self {
+        Fees(Map::new("Fees"))
+    }
+
+    pub fn add(&self, deps: DepsMut, address: Account, value: u128) {
+     match !self.0.has(deps.storage, address.clone() ) {
+        true => {
+            self.0.save(deps.storage,address,&value);
+            }
+        false => (),
+    }
+        }
+        
+            
+    pub fn remove(&self, deps: DepsMut, address: Account, value: u128)  {
+        if self.0.has(deps.storage, address.clone())  {
+            self.0.remove(deps.storage, address);
+        }
+    }
+
+    pub fn get(&self, deps: DepsMut, address: Account, value: u128) -> StdResult<u128> {
+        self.0.load(deps.storage, address)
+    }
+
+    pub fn contains(&self, deps: DepsMut, address: Account, value: u128) -> bool {
+        self.0.has(deps.storage, address)
+    }
+}
+
+mod tests {
+    // use crate::tests;
+
+    use crate::add;
+
+    use super::{Fees, Account};
+    use cosmwasm::mock::{self, MockApi, MockStorage};
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+
+    fn storage(){
+        
+    }
+
+    #[test]
+    fn contains_account(){
+        let mut deps = mock_dependencies();
+        let mut fees = Fees::new();
+        let mock_storage = mock::MockStorage::new();
+         let address = "88bd05442686be0a5df7da33b6f1089ebfea3769b19dbb2477fe0cd6e0f126e4".to_string();
+         let value = 3402823669209384634;
+
+        let result = fees.contains(deps.as_mut(), address, value);
+        return 
+    }
+
+    #[test]
+    fn removing_account(){
+        let mut deps = mock_dependencies();
+        let mut fees = Fees::new();
+        let mock_storage=mock::MockStorage::new();
+        let address = "88bd05442686be0a5df7da33b6f1089ebfea3769b19dbb2477fe0cd6e0f126e4".to_string();
+        let value = 3402823669209384634;
+
+        fees.contains(deps.as_mut(), address.clone(), value);
+        let result = fees.remove(deps.as_mut(), address.clone(), value);
+    }
+     
+    #[test]
+    fn adding_existing_account(){
+        let mut deps = mock_dependencies();
+        let mut fees = Fees::new();
+        let mock_storage=mock::MockStorage::new();
+        let address = " ".to_string();
+        let value = 0;
+
+        fees.contains(deps.as_mut(), address.clone(), value);
+        let result = fees.add(deps.as_mut(), address.clone(), value);
+
+    }
+
+    #[test]
+    fn removing_non_existing_account(){
+        let mut deps = mock_dependencies();
+        let mut fees = Fees::new();
+        let mock_storage = mock::MockStorage::new();
+        let address = "88bd05442686be0a5df7da33b6f1089ebfea3769b19dbb2477fe0cd6e0f126e4".to_string();
+        let value = 3402823669209384634;
+
+        fees.contains(deps.as_mut(), address, value);
+        // match fees.get(deps.as_mut(), address, value) {
+        //     true => {
+        //         let result = fees.remove(deps.as_mut(), address, value);
+        //         }
+        //     false => return,
+        // }
+
+    }
+
+    #[test]
+    fn get_account(){
+        let mut deps = mock_dependencies();
+        let mut fees = Fees::new();
+        let mock_storage = mock::MockStorage::new();
+        let address = "88bd05442686be0a5df7da33b6f1089ebfea3769b19dbb2477fe0cd6e0f126e4".to_string();
+        let value = 3402823669209384634;
+
+        fees.get(deps.as_mut(), address, value);
+    }
+
+    #[test]
+    fn setting_account(){
+        let mut deps = mock_dependencies();
+        let mut fees = Fees::new();
+        let mock_storage = mock::MockStorage::new();
+        let address = "88bd05442686be0a5df7da33b6f1089ebfea3769b19dbb2477fe0cd6e0f126e4".to_string();
+        let value = 3402823669209384634;
+
+        fees.add(deps.as_mut(), address, value);
+    }
+   
+    #[test]
+    fn getting_non_existing_account(){
+        // let mut deps = mock_dependencies();
+        // let mut fees = Fees::new();
+        // let mock_storage = mock::MockStorage::new();
+        // let address = "88bd05442686be0a5df7da33b6f1089ebfea3769b19dbb2477fe0cd6e0f126e4".to_string();
+        // let value = 3402823669209384634;
+
+
+    }
+
+   
+
+
+
+    
+
+}

--- a/contracts/cosmwasm-vm/libraries/src/lib.rs
+++ b/contracts/cosmwasm-vm/libraries/src/lib.rs
@@ -1,0 +1,16 @@
+mod fees;
+
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/docs/terminologies/ibc_terminologies.md
+++ b/docs/terminologies/ibc_terminologies.md
@@ -1,0 +1,112 @@
+## Terminologies
+
+- [ibc packet](#ibc-packet)
+  
+The IbcPacket structure contains all information needed to process the receipt. This info has already been verified by the core IBC modules via light client and merkle proofs
+
+- [ibc message](#ibc-message)
+
+Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. 
+
+- #### xCall Handshakes 
+
+This will occurs between the two chains
+
+- [OpenInit](#openinit)
+
+ OpenInit initializes any connection which may occur, while still necessitating agreement from both sides
+
+- [OpenTry](#opentry)
+
+OpenInit is followed by an OpenTry response, in which chain B verifies the identity of chain A according to information that chain B has about chain A in its light client
+
+- [OpenAck](#openack)
+
+ OpenAck is very similar to the functionality of OpenInit, except that the information verification now occurs for chain A.
+
+- [OpenConfirm](#openconfirm)
+
+ OpenConfirm is the final handshake, in which chain B confirms that both self-identification and counterparty identification were successful.
+
+---
+
+### ibc packet
+
+The IbcPacket structure contains all information needed to process the receipt. This info has already been verified by the core IBC modules via light client and merkle proofs
+
+It has following fields:
+
+| Name     | Type      | Description                                           |
+|:---------|:----------|:------------------------------------------------------|
+| data     | Binary    | The raw data send from the other side in the packet   |
+| src      |IbcEndpoint| identifies the channel and port on the sending chain  |
+| dest     |IbcEndpoint| identifies the channel and port on the receiving chain|
+| sequence | u64       | The sequence number of the packet on the given channel|
+|timeout   |IbcTimeout | Timeout object                                        |
+
+### ibc message
+
+Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain.
+
+| Name       | Type      | Description                                           |
+|:---------  |:----------|:------------------------------------------------------|
+|channel Id  | String    | exisiting channel to send the tokens over             |
+| to_address | String    | address on the remote chain to receive these tokens   |
+| amount     | Coin      | packet data only supports one coin                    |
+| timeout    | IbcTimeout| when packet times out, measured on remote chain       |
+
+### openInit
+
+OpenInit initializes any connection which may occur, while still necessitating agreement from both sides
+
+| Name         | Type          | Description                                           |
+|:-------------|:--------------|:------------------------------------------------------|
+|clientID      | String        | exisiting client to send the tokens over              |
+| counterparty | Counterparty  | identifies the channel in the receiving chain         |
+| version      | Version       | packet data only supports one coin                    |
+| delayPeriod  | IbcTimeout    | Timeout                                               |
+
+### openTry
+
+openInit is followed by an OpenTry response, in which chain B verifies the identity of chain A according to information that chain B has about chain A in its light client
+
+| Name         | Type          | Description                                                         |
+|:-------------|:--------------|:--------------------------------------------------------------------|
+|clientID      | String        | exisiting client to send the tokens over                            |
+| counterparty | Counterparty  | identifies the channel in the receiving chain                       |
+| version      | Version       | packet data only supports one coin                                  |
+| delayPeriod  | IbcTimeout    | Timeout                                                             |
+| proofInit    | u128          | proof that chainA stored connectionEnd in state                     |
+|proofConsensus| u128          | packet data only supports one coin                                  |
+| proofClient  | u128          | proof that chainA stored a light client of chainB                   |   
+| proofHeight  | u128          | height at which relayer constructs proof of A storing connectionEnd |
+
+### openAck 
+
+OpenAck is very similar to the functionality of OpenInit, except that the information verification now occurs for chain A.
+
+| Name         | Type          | Description                                                         |
+|:-------------|:--------------|:--------------------------------------------------------------------|
+|clientID      | String        | exisiting client to send the tokens over                            |
+| counterparty | Counterparty  | identifies the channel in the receiving chain                       |
+| version      | Version       | packet data only supports one coin                                  |
+| delayPeriod  | IbcTimeout    | Timeout                                                             |
+| proofInit    | u128          | proof that chainA stored connectionEnd in state                     |
+|proofConsensus| u128          | packet data only supports one coin                                  |
+| proofClient  | u128          | proof that chainA stored a light client of chainB                   |   
+| proofHeight  | u128          | height at which relayer constructs proof of A storing connectionEnd |
+
+### openConfirm
+
+| Name         | Type          | Description                                                         |
+|:-------------|:--------------|:--------------------------------------------------------------------|
+|connectionId  | String        | exisiting connection to send the tokens over                        |
+| proofAck     | u128          | proof that connection opened on Chain A during ConnOpenAck          |
+| version      | Version       | packet data only supports one coin                                  |
+|  proofHeight |u128           | height at which relayer constructs proof of A storing connectionEnd |
+
+
+
+
+
+


### PR DESCRIPTION
## Description:

Owner of the contract can call this method to set the address for fee handler using set_protocol_fee_handler.

A user can query current fee handler address of a  protocol using get_protocol_fee_handler

### Commit Message

```bash
feat: protocol fee handler
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
