### PR TITLE
feat: 65-user-story-connection-creating-event-for-openinit-and-openack

### DIFF
--- a/contracts/cosmwasm-vm/cw-ibc-core/tests/test_connection.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/tests/test_connection.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 pub mod setup;
-use cosmwasm_std::testing::MockStorage;
 use cw_ibc_core::ics03_connection::event::event_open_ack;
 use cw_ibc_core::ics03_connection::event::event_open_init;
 use cw_ibc_core::types::ClientType;
@@ -77,16 +76,18 @@ fn test_get_connection() {
 
 #[test]
 fn test_connection_sequence() {
-    let mut store = MockStorage::default();
+    let mut store = deps();
     let contract = CwIbcCoreContext::new();
     contract
-        .connection_next_sequence_init(&mut store, u128::default())
+        .connection_next_sequence_init(store.as_mut().storage, u128::default())
         .unwrap();
-    let result = contract.connection_counter(&mut store).unwrap();
+    let result = contract.connection_counter(store.as_ref().storage).unwrap();
 
     assert_eq!(0, result);
 
-    let increment_sequence = contract.increase_connection_counter(&mut store).unwrap();
+    let increment_sequence = contract
+        .increase_connection_counter(store.as_mut().storage)
+        .unwrap();
     assert_eq!(1, increment_sequence);
 }
 
@@ -135,11 +136,9 @@ fn test_set_connection_fail() {
 #[test]
 #[should_panic(expected = "Std(NotFound { kind: \"u128\" })")]
 fn test_connection_sequence_fail() {
-    let mut store = MockStorage::default();
+    let store = deps();
     let contract = CwIbcCoreContext::new();
-    contract.connection_counter(&mut store).unwrap();
-
-    contract.increase_connection_counter(&mut store).unwrap();
+    contract.connection_counter(store.as_ref().storage).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Description:

As a developer, I want to create an event for the "open_init" message that is emitted when a new connection is initiated between two chains, so that other modules can subscribe to these events and perform additional logic.

As a developer, I want to ensure that the "open_ack" event is emitted at the appropriate time, such as immediately after the "conn_open_ack" message is received, so that subscribers receive the event in a timely and predictable manner

### Commit Message

```bash
feat: created event for openinit and openack
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
