### PR TITLE
fix(javascore): fix method name used for encoding integers in javascore proto generator

### DIFF
--- a/contracts/javascore/proto-util/src/main/java/icon/score/proto/ProtoGen.java
+++ b/contracts/javascore/proto-util/src/main/java/icon/score/proto/ProtoGen.java
@@ -50,10 +50,10 @@ public class ProtoGen {
 
             final Importer importer = injector.getInstance(Importer.class);
 
-            Iterator it = FileUtils.iterateFiles(new File(path), new String[] { "proto" },
+            Iterator<File> it = FileUtils.iterateFiles(new File(path), new String[] { "proto" },
                     true);
             while (it.hasNext()) {
-                File file = (File) it.next();
+                File file = it.next();
                 String filePath = file.getPath().replace(path + "/", "");
                 final ProtoContext protoContext = importer.importFile(fileReader, filePath);
                 final Proto proto = protoContext.getProto();
@@ -88,7 +88,7 @@ public class ProtoGen {
         }
     }
 
-    private static TypeSpec.Builder createEnum(io.protostuff.compiler.model.Enum protoEnum) throws Exception {
+    private static TypeSpec.Builder createEnum(io.protostuff.compiler.model.Enum protoEnum) {
         TypeSpec.Builder enumSpec = TypeSpec.classBuilder(protoEnum.getName())
                 .addModifiers(Modifier.PUBLIC);
         for (EnumConstant _enum : protoEnum.getConstants()) {
@@ -100,8 +100,7 @@ public class ProtoGen {
         return enumSpec;
     }
 
-    private static TypeSpec.Builder createMessage(Message protoMessage)
-            throws Exception {
+    private static TypeSpec.Builder createMessage(Message protoMessage) {
         TypeSpec.Builder messageSpec = TypeSpec.classBuilder(protoMessage.getName())
                 .addModifiers(Modifier.PUBLIC)
                 .superclass(ProtoMessage.class);
@@ -346,7 +345,7 @@ public class ProtoGen {
             case "uint64":
             case "sint32":
             case "sint64":
-                return "encodeVarIntArrayArray";
+                return "encodeVarIntArray";
             case "fixed32":
             case "sfixed32":
                 throw new IllegalArgumentException("Type currently not supported " + field.getTypeName());


### PR DESCRIPTION


## Description:
The correct method name available in proto library is `encodeVarIntArray`. The proto generator used wrong method name.

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have run the unit tests
- [X] I only have one commit (if not, squash them into one commit).
- [X] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
