### PR TITLE
feat: 72-implementing-query-get-connection

### DIFF
--- a/contracts/cosmwasm-vm/cw-ibc-core/tests/test_connection.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/tests/test_connection.rs
@@ -1,9 +1,7 @@
-use std::error::Error;
 use std::time::Duration;
 
 pub mod setup;
 use cosmwasm_std::to_vec;
-use cosmwasm_std::StdError;
 use cw_ibc_core::context::CwIbcCoreContext;
 use cw_ibc_core::ics02_client::types::ClientState;
 use cw_ibc_core::ics03_connection::event::create_open_ack_event;
@@ -13,7 +11,6 @@ use cw_ibc_core::ics03_connection::event::create_open_try_event;
 use cw_ibc_core::types::ClientId;
 use cw_ibc_core::types::ConnectionId;
 use cw_ibc_core::ConnectionEnd;
-use cw_ibc_core::ContractError;
 use cw_ibc_core::IbcClientId;
 use ibc::core::ics03_connection::connection::Counterparty;
 use ibc::core::ics03_connection::connection::State;


### PR DESCRIPTION
## Description:

As a developer, I want the "get_connection" query handler to be able to retrieve and share basic information about the connection, such as its ID, state, and associated counterparty.

### Commit Message

```bash
feat: implement query get connection
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
