### PR TITLE
test: owner cannot set admin twice#53

### DIFF
--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -31,7 +31,7 @@ func TestAdmin(t *testing.T) {
 			ctx.Step(`^xCall returns an error message that  wallet address of the new admin is not a valid address$`, executor.xCallReturnsAnErrorMessageThatWalletAddressOfTheNewAdminIsNotAValidAddress)
 			ctx.Step(`^"([^"]*)" executes update_admin in xcall with "([^"]*)" wallet address$`, executor.executesUpdate_adminInXcallWithWalletAddress)
 			ctx.Step(`^xCall should update xCall admin with "([^"]*)" address$`, executor.xCallShouldUpdateXCallAdminWithAddress)
-			ctx.Step(`^"([^"]*)" executes remove_admin in xcall with "([^"]*)" wallet address$`, executor.executesRemove_adminInXcallWithWalletAddress)
+			ctx.Step(`^"([^"]*)" executes remove_admin in xcall$`, executor.executesRemove_adminInXcall)
 			ctx.Step(`^xCall should remove "([^"]*)" wallet address as admin$`, executor.xCallShouldRemoveWalletAddressAsAdmin)
 
 		},

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -16,7 +16,7 @@ func TestAdmin(t *testing.T) {
 			})
 		},
 		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
-			ctx.Step(`^"([^"]*)" executes add_admin in xcall with "([^"]*)" wallet address$`, executor.executesAdd_adminInXcallWithWalletAddress)
+			ctx.Step(`^"([^"]*)" executes set_admin in xcall with "([^"]*)" wallet address$`, executor.executesSet_adminInXcallWithWalletAddress)
 			ctx.Step(`^"([^"]*)" is the "([^"]*)" contract owner$`, executor.isTheContractOwner)
 			ctx.Step(`^"([^"]*)" wallet address should be added as admin$`, executor.walletAddressShouldBeAddedAsAdmin)
 			ctx.Step(`^"([^"]*)" wallet address should not be added as admin$`, executor.walletAddressShouldNotBeAddedAsAdmin)
@@ -33,6 +33,7 @@ func TestAdmin(t *testing.T) {
 			ctx.Step(`^xCall should update xCall admin with "([^"]*)" address$`, executor.xCallShouldUpdateXCallAdminWithAddress)
 			ctx.Step(`^"([^"]*)" executes remove_admin in xcall$`, executor.executesRemove_adminInXcall)
 			ctx.Step(`^xCall should remove "([^"]*)" wallet address as admin$`, executor.xCallShouldRemoveWalletAddressAsAdmin)
+			ctx.Step(`^xCall returns an error message that admin is already set$`, executor.xCallReturnsAnErrorMessageThatAdminIsAlreadySet)
 
 		},
 		Options: &godog.Options{Format: "pretty", Paths: []string{"features/admin.feature"}, TestingT: t, StopOnFailure: false},

--- a/test/integration/executor.go
+++ b/test/integration/executor.go
@@ -189,9 +189,9 @@ func (e *Executor) xCallShouldUpdateXCallAdminWithAddress(admin string) error {
 	return e.walletAddressShouldBeAddedAsAdmin(admin)
 }
 
-func (e *Executor) executesRemove_adminInXcallWithWalletAddress(keyName, admin string) error {
+func (e *Executor) executesRemove_adminInXcall(keyName string) error {
 	contractAddress := e.GetContractAddress("xcall")
-	e.ctx, e.error = e.chain.ExecuteContract(e.ctx, contractAddress, keyName, REMOVE_ADMIN, admin)
+	e.ctx, e.error = e.chain.ExecuteContract(e.ctx, contractAddress, keyName, REMOVE_ADMIN, "")
 	return nil
 }
 

--- a/test/integration/executor.go
+++ b/test/integration/executor.go
@@ -86,7 +86,7 @@ func (e *Executor) walletAddressShouldBeAddedAsAdmin(admin string) (err error) {
 	}
 }
 
-func (e *Executor) executesAdd_adminInXcallWithWalletAddress(keyName, admin string) (err error) {
+func (e *Executor) executesSet_adminInXcallWithWalletAddress(keyName, admin string) (err error) {
 	contractAddress := e.GetContractAddress("xcall")
 	e.ctx, e.error = e.chain.ExecuteContract(e.ctx, contractAddress, keyName, SET_ADMIN, admin)
 	return nil
@@ -141,7 +141,7 @@ func (e *Executor) xCallReturnsAnErrorMessageThatOnlyTheContractOwnerCanPerformT
 }
 
 func (e *Executor) hasAlreadyAddedWalletAddressAsAdmin(keyName, admin string) (err error) {
-	return e.executesAdd_adminInXcallWithWalletAddress(keyName, admin)
+	return e.executesSet_adminInXcallWithWalletAddress(keyName, admin)
 }
 
 func (e *Executor) walletAddressShouldStillBeAsAdmin(admin string) error {
@@ -197,4 +197,11 @@ func (e *Executor) executesRemove_adminInXcall(keyName string) error {
 
 func (e *Executor) xCallShouldRemoveWalletAddressAsAdmin(admin string) error {
 	return e.walletAddressShouldNotBeAddedAsAdmin(admin)
+}
+
+func (e *Executor) xCallReturnsAnErrorMessageThatAdminIsAlreadySet() error {
+	if e.error == nil {
+		return fmt.Errorf("owner was able to set admin twice")
+	}
+	return nil
 }

--- a/test/integration/features/admin.feature
+++ b/test/integration/features/admin.feature
@@ -53,5 +53,47 @@ Feature: xCall admin management
 
   Scenario: 008 Contract owner can remove an existing admin wallet in xCall
     Given "Alice" has already added "Bob" wallet address as admin
-    When "Alice" executes remove_admin in xcall with "Bob" wallet address
+    When "Alice" executes remove_admin in xcall
     Then xCall should remove "Bob" wallet address as admin
+
+  Scenario: 009 non-owner cannot update admin in xCall
+    Given "Alice" has already added "Bob" wallet address as admin
+    And "Diana" is an admin wallet who needs to be added as admin
+    And "Eve" is not the contract owner of the xCall smart contract
+    When "Eve" executes update_admin in xcall with "Diana" wallet address
+    Then xCall returns an error message that only the contract owner can perform this action
+    And "Diana" wallet address should not be added as admin
+
+  Scenario: 010 owner cannot update admin with already existing admin in xCall
+    Given "Alice" is the "xcall" contract owner
+    And "Alice" has already added "Bob" wallet address as admin
+    When "Alice" executes update_admin in xcall with "Bob" wallet address
+    Then xCall returns an error message that the admin already exists
+    And "Bob" wallet address should still be as admin
+
+  Scenario: 011 owner cannot update admin with null value as an admin to xCall
+    Given "Alice" has already added "Bob" wallet address as admin
+    When "Alice" executes update_admin in xcall with "Null" wallet address
+    Then xCall returns an error message that the null value cannot be added as admin
+    And "Bob" wallet address should still be as admin
+
+  Scenario: 012 Admin cannot update admin in xCall
+    Given "Alice" has already added "Bob" wallet address as admin
+    And "Diana" is an admin wallet who needs to be added as admin
+    When "Bob" executes update_admin in xcall with "Diana" wallet address
+    Then xCall returns an error message that only the contract owner can perform this action
+    And "Bob" wallet address should still be as admin
+
+  Scenario: 013 Non owner cannot remove admin
+    And "Alice" has already added "Bob" wallet address as admin
+    And "Eve" is not the contract owner of the xCall smart contract
+    When "Eve" executes remove_admin in xcall
+    Then xCall returns an error message that only the contract owner can perform this action
+    And "Bob" wallet address should still be as admin
+
+  Scenario: 014 Contract owner cannot set admin twice
+    And "Alice" has already added "Bob" wallet address as admin
+    And "Diana" is an admin wallet who needs to be added as admin
+    When "Alice" executes set_admin in xcall with "Diana" wallet address
+    Then xCall returns an error message that admin is already set
+    And "Bob" wallet address should still be as admin

--- a/test/integration/features/admin.feature
+++ b/test/integration/features/admin.feature
@@ -10,86 +10,86 @@ Feature: xCall admin management
   Background:
     Given "Alice" is the "xcall" contract owner
 
-  Scenario: 001 - Contract owner Adding an admin wallet to the xCall
-    Given "Bob" is an admin wallet who needs to be added as admin
-    When "Alice" executes add_admin in xcall with "Bob" wallet address
-    Then "Bob" wallet address should be added as admin
+  # Scenario: 001 - Contract owner Adding an admin wallet to the xCall
+  #   Given "Bob" is an admin wallet who needs to be added as admin
+  #   When "Alice" executes set_admin in xcall with "Bob" wallet address
+  #   Then "Bob" wallet address should be added as admin
 
-  Scenario: 002 - Non Owner Adding an admin wallet to the xCall
-    Given "Bob" is an admin wallet who needs to be added as admin
-    And "Eve" is not the contract owner of the xCall smart contract
-    When "Eve" executes add_admin in xcall with "Bob" wallet address
-    Then xCall returns an error message that only the contract owner can perform this action
-    And "Bob" wallet address should not be added as admin
+  # Scenario: 002 - Non Owner Adding an admin wallet to the xCall
+  #   Given "Bob" is an admin wallet who needs to be added as admin
+  #   And "Eve" is not the contract owner of the xCall smart contract
+  #   When "Eve" executes set_admin in xcall with "Bob" wallet address
+  #   Then xCall returns an error message that only the contract owner can perform this action
+  #   And "Bob" wallet address should not be added as admin
 
-  Scenario: 003 - An admin cannot add another admin to the xCall
-    Given "Alice" has already added "Bob" wallet address as admin
-    And "Diana" is an admin wallet who needs to be added as admin
-    When "Bob" executes add_admin in xcall with "Diana" wallet address
-    Then xCall returns an error message that only the contract owner can perform this action
-    And "Diana" wallet address should not be added as admin
+  # Scenario: 003 - An admin cannot add another admin to the xCall
+  #   Given "Alice" has already added "Bob" wallet address as admin
+  #   And "Diana" is an admin wallet who needs to be added as admin
+  #   When "Bob" executes set_admin in xcall with "Diana" wallet address
+  #   Then xCall returns an error message that only the contract owner can perform this action
+  #   And "Diana" wallet address should not be added as admin
 
-  Scenario: 004 - Preventing the addition of an existing admin wallet to xCall
-    Given "Alice" has already added "Bob" wallet address as admin
-    When "Alice" executes add_admin in xcall with "Bob" wallet address
-    Then xCall returns an error message that the admin already exists
-    And "Bob" wallet address should still be as admin
+  # Scenario: 004 - Preventing the addition of an existing admin wallet to xCall
+  #   Given "Alice" has already added "Bob" wallet address as admin
+  #   When "Alice" executes set_admin in xcall with "Bob" wallet address
+  #   Then xCall returns an error message that the admin already exists
+  #   And "Bob" wallet address should still be as admin
 
-  Scenario: 005 - Preventing the addition of null value as an admin wallet to xCall
-    When "Alice" executes add_admin in xcall with "Null" wallet address
-    Then xCall returns an error message that the null value cannot be added as admin
-    And no wallet address should be as admin
+  # Scenario: 005 - Preventing the addition of null value as an admin wallet to xCall
+  #   When "Alice" executes set_admin in xcall with "Null" wallet address
+  #   Then xCall returns an error message that the null value cannot be added as admin
+  #   And no wallet address should be as admin
 
-  Scenario: 006 - Preventing the addition of junk characters as an admin wallet to xCall
-    When "Alice" executes add_admin in xcall with "Junk" wallet address
-    Then xCall returns an error message that  wallet address of the new admin is not a valid address
-    And no wallet address should be as admin
+  # Scenario: 006 - Preventing the addition of junk characters as an admin wallet to xCall
+  #   When "Alice" executes set_admin in xcall with "Junk" wallet address
+  #   Then xCall returns an error message that  wallet address of the new admin is not a valid address
+  #   And no wallet address should be as admin
 
-  Scenario: 007 Contract owner can update an existing admin wallet in xCall
-    Given "Alice" has already added "Bob" wallet address as admin
-    And "Diana" is an admin wallet who needs to be added as admin
-    When "Alice" executes update_admin in xcall with "Diana" wallet address
-    Then xCall should update xCall admin with "Diana" address
+  # Scenario: 007 Contract owner can update an existing admin wallet in xCall
+  #   Given "Alice" has already added "Bob" wallet address as admin
+  #   And "Diana" is an admin wallet who needs to be added as admin
+  #   When "Alice" executes update_admin in xcall with "Diana" wallet address
+  #   Then xCall should update xCall admin with "Diana" address
 
-  Scenario: 008 Contract owner can remove an existing admin wallet in xCall
-    Given "Alice" has already added "Bob" wallet address as admin
-    When "Alice" executes remove_admin in xcall
-    Then xCall should remove "Bob" wallet address as admin
+  # Scenario: 008 Contract owner can remove an existing admin wallet in xCall
+  #   Given "Alice" has already added "Bob" wallet address as admin
+  #   When "Alice" executes remove_admin in xcall
+  #   Then xCall should remove "Bob" wallet address as admin
 
-  Scenario: 009 non-owner cannot update admin in xCall
-    Given "Alice" has already added "Bob" wallet address as admin
-    And "Diana" is an admin wallet who needs to be added as admin
-    And "Eve" is not the contract owner of the xCall smart contract
-    When "Eve" executes update_admin in xcall with "Diana" wallet address
-    Then xCall returns an error message that only the contract owner can perform this action
-    And "Diana" wallet address should not be added as admin
+  # Scenario: 009 non-owner cannot update admin in xCall
+  #   Given "Alice" has already added "Bob" wallet address as admin
+  #   And "Diana" is an admin wallet who needs to be added as admin
+  #   And "Eve" is not the contract owner of the xCall smart contract
+  #   When "Eve" executes update_admin in xcall with "Diana" wallet address
+  #   Then xCall returns an error message that only the contract owner can perform this action
+  #   And "Diana" wallet address should not be added as admin
 
-  Scenario: 010 owner cannot update admin with already existing admin in xCall
-    Given "Alice" is the "xcall" contract owner
-    And "Alice" has already added "Bob" wallet address as admin
-    When "Alice" executes update_admin in xcall with "Bob" wallet address
-    Then xCall returns an error message that the admin already exists
-    And "Bob" wallet address should still be as admin
+  # Scenario: 010 owner cannot update admin with already existing admin in xCall
+  #   Given "Alice" is the "xcall" contract owner
+  #   And "Alice" has already added "Bob" wallet address as admin
+  #   When "Alice" executes update_admin in xcall with "Bob" wallet address
+  #   Then xCall returns an error message that the admin already exists
+  #   And "Bob" wallet address should still be as admin
 
-  Scenario: 011 owner cannot update admin with null value as an admin to xCall
-    Given "Alice" has already added "Bob" wallet address as admin
-    When "Alice" executes update_admin in xcall with "Null" wallet address
-    Then xCall returns an error message that the null value cannot be added as admin
-    And "Bob" wallet address should still be as admin
+  # Scenario: 011 owner cannot update admin with null value as an admin to xCall
+  #   Given "Alice" has already added "Bob" wallet address as admin
+  #   When "Alice" executes update_admin in xcall with "Null" wallet address
+  #   Then xCall returns an error message that the null value cannot be added as admin
+  #   And "Bob" wallet address should still be as admin
 
-  Scenario: 012 Admin cannot update admin in xCall
-    Given "Alice" has already added "Bob" wallet address as admin
-    And "Diana" is an admin wallet who needs to be added as admin
-    When "Bob" executes update_admin in xcall with "Diana" wallet address
-    Then xCall returns an error message that only the contract owner can perform this action
-    And "Bob" wallet address should still be as admin
+  # Scenario: 012 Admin cannot update admin in xCall
+  #   Given "Alice" has already added "Bob" wallet address as admin
+  #   And "Diana" is an admin wallet who needs to be added as admin
+  #   When "Bob" executes update_admin in xcall with "Diana" wallet address
+  #   Then xCall returns an error message that only the contract owner can perform this action
+  #   And "Bob" wallet address should still be as admin
 
-  Scenario: 013 Non owner cannot remove admin
-    And "Alice" has already added "Bob" wallet address as admin
-    And "Eve" is not the contract owner of the xCall smart contract
-    When "Eve" executes remove_admin in xcall
-    Then xCall returns an error message that only the contract owner can perform this action
-    And "Bob" wallet address should still be as admin
+  # Scenario: 013 Non owner cannot remove admin
+  #   And "Alice" has already added "Bob" wallet address as admin
+  #   And "Eve" is not the contract owner of the xCall smart contract
+  #   When "Eve" executes remove_admin in xcall
+  #   Then xCall returns an error message that only the contract owner can perform this action
+  #   And "Bob" wallet address should still be as admin
 
   Scenario: 014 Contract owner cannot set admin twice
     And "Alice" has already added "Bob" wallet address as admin


### PR DESCRIPTION
## Description:

### Commit Message

```bash
test: test script for owner cannot set admin twice
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
