### PR TITLE
fix: 84 bugxcall contract panics when we query get admin when list is empty

### DIFF
--- a/contracts/cosmwasm-vm/cw-xcall/src/admin.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/src/admin.rs
@@ -2,7 +2,10 @@ use super::*;
 
 impl<'a> CwCallService<'a> {
     pub fn query_admin(&self, store: &dyn Storage) -> Result<Address, ContractError> {
-        let admin = self.admin().load(store)?;
+        let admin = self
+            .admin()
+            .load(store)
+            .map_err(|_| ContractError::AdminNotExist)?;
 
         Ok(admin)
     }
@@ -15,6 +18,12 @@ impl<'a> CwCallService<'a> {
     ) -> Result<Response, ContractError> {
         if admin.is_empty() {
             return Err(ContractError::AdminAddressCannotBeNull {});
+        }
+        //TODO : Check for address length
+        if !admin.to_string().chars().all(|x| x.is_alphanumeric()) {
+            return Err(ContractError::InvalidAddress {
+                address: admin.to_string(),
+            });
         }
 
         let owner = self
@@ -46,6 +55,13 @@ impl<'a> CwCallService<'a> {
         if new_admin.is_empty() {
             return Err(ContractError::AdminAddressCannotBeNull {});
         }
+
+        if !new_admin.to_string().chars().all(|x| x.is_alphanumeric()) {
+            return Err(ContractError::InvalidAddress {
+                address: new_admin.to_string(),
+            });
+        }
+
         let owner = self.owner().load(store)?;
 
         if info.sender != owner.to_string() {

--- a/contracts/cosmwasm-vm/cw-xcall/src/contract.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/src/contract.rs
@@ -98,7 +98,13 @@ impl<'a> CwCallService<'a> {
 
     pub fn query(&self, deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         match msg {
-            QueryMsg::GetAdmin {} => to_binary(&self.query_admin(deps.storage).unwrap()),
+            QueryMsg::GetAdmin {} => match self.query_admin(deps.storage) {
+                Ok(admin) => Ok(to_binary(&admin)?),
+                Err(error) => Err(StdError::NotFound {
+                    kind: error.to_string(),
+                }),
+            },
+
             QueryMsg::GetProtocolFee {} => to_binary(&self.get_protocol_fee(deps)),
             QueryMsg::GetProtocolFeeHandler {} => to_binary(&self.get_protocol_feehandler(deps)),
         }

--- a/contracts/cosmwasm-vm/cw-xcall/src/error.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/src/error.rs
@@ -38,4 +38,6 @@ pub enum ContractError {
     OnlyAdmin,
     #[error("AdminAddressCannotBeNull")]
     AdminAddressCannotBeNull {},
+    #[error("InvalidAddress {address}")]
+    InvalidAddress { address: String },
 }

--- a/contracts/cosmwasm-vm/cw-xcall/src/types/address.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/src/types/address.rs
@@ -1,3 +1,5 @@
+use cosmwasm_std::Addr;
+
 use super::*;
 
 #[cw_serde]

--- a/contracts/cosmwasm-vm/cw-xcall/tests/test_admin.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/tests/test_admin.rs
@@ -1,6 +1,7 @@
 mod account;
 mod setup;
 use account::*;
+use cosmwasm_std::{from_binary, testing::mock_env};
 use cw_xcall::{state::CwCallService, types::address::Address};
 use setup::*;
 
@@ -235,6 +236,81 @@ fn add_admin_with_empty_address() {
             mock_deps.as_mut().storage,
             mock_info.clone(),
             Address::from(""),
+        )
+        .unwrap();
+}
+
+#[test]
+fn query_admin() {
+    let mock_deps = deps();
+
+    let mock_env = mock_env();
+
+    let contract = CwCallService::default();
+
+    let result = contract.query(
+        mock_deps.as_ref(),
+        mock_env,
+        cw_xcall::msg::QueryMsg::GetAdmin {},
+    );
+
+    assert!(result.is_err())
+}
+
+#[test]
+#[should_panic(expected = "InvalidAddress { address: \"*************\"")]
+fn add_invalid_char_as_admin() {
+    let mut mock_deps = deps();
+
+    let mock_info = create_mock_info(&alice().to_string(), "umlg", 2000);
+
+    let contract = CwCallService::default();
+
+    contract
+        .add_owner(
+            mock_deps.as_mut().storage,
+            Address::from(&mock_info.sender.to_string()),
+        )
+        .unwrap();
+
+    contract
+        .add_admin(
+            mock_deps.as_mut().storage,
+            mock_info.clone(),
+            "*************".into(),
+        )
+        .unwrap();
+}
+
+#[test]
+#[should_panic(expected = "InvalidAddress { address: \"*****%%%%%@@@###!1234hello\"")]
+fn update_admin_invalid_chars() {
+    let mut mock_deps = deps();
+
+    let mock_info = create_mock_info(&alice().to_string(), "umlg", 2000);
+
+    let contract = CwCallService::default();
+
+    contract
+        .add_owner(
+            mock_deps.as_mut().storage,
+            Address::from(&mock_info.sender.to_string()),
+        )
+        .unwrap();
+
+    contract
+        .add_admin(mock_deps.as_mut().storage, mock_info.clone(), admin_one())
+        .unwrap();
+
+    let result = contract.query_admin(mock_deps.as_ref().storage).unwrap();
+
+    assert_eq!(result, admin_one());
+
+    contract
+        .update_admin(
+            mock_deps.as_mut().storage,
+            mock_info.clone(),
+            "*****%%%%%@@@###!1234hello".into(),
         )
         .unwrap();
 }


### PR DESCRIPTION
## Description:

### Commit Message

```bash
fix: handle panic and return error and Update add admin with address validation
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.



## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
