### PR TITLE
fix: invalid chars cannot be added as admin address

### DIFF
--- a/contracts/cosmwasm-vm/cw-xcall/src/admin.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/src/admin.rs
@@ -19,12 +19,6 @@ impl<'a> CwCallService<'a> {
         if admin.is_empty() {
             return Err(ContractError::AdminAddressCannotBeNull {});
         }
-        //TODO : Check for address length
-        if !admin.to_string().chars().all(|x| x.is_alphanumeric()) {
-            return Err(ContractError::InvalidAddress {
-                address: admin.to_string(),
-            });
-        }
 
         let owner = self
             .owner()
@@ -96,5 +90,19 @@ impl<'a> CwCallService<'a> {
         } else {
             Err(ContractError::Unauthorized {})
         }
+    }
+
+    pub fn validate_address(api: &dyn Api, address: &str) -> Result<Address, ContractError> {
+        if !address.chars().all(|x| x.is_alphanumeric()) {
+            return Err(ContractError::InvalidAddress {
+                address: address.to_string(),
+            });
+        }
+
+        let validated_address = api
+            .addr_validate(address)
+            .map_err(|error| ContractError::Std(error))?;
+
+        Ok(validated_address.as_str().into())
     }
 }

--- a/contracts/cosmwasm-vm/cw-xcall/src/contract.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/src/contract.rs
@@ -29,7 +29,11 @@ impl<'a> CwCallService<'a> {
         msg: ExecuteMsg,
     ) -> Result<Response, ContractError> {
         match msg {
-            ExecuteMsg::SetAdmin { address } => self.add_admin(deps.storage, info, address),
+            ExecuteMsg::SetAdmin { address } => {
+                let validated_address =
+                    CwCallService::validate_address(deps.api, address.as_str())?;
+                self.add_admin(deps.storage, info, validated_address)
+            }
             ExecuteMsg::SetProtocol { value } => self.set_protocol_fee(deps, info, value),
             ExecuteMsg::SetProtocolFeeHandler { address } => {
                 self.set_protocol_feehandler(deps, env, info, address)
@@ -91,7 +95,11 @@ impl<'a> CwCallService<'a> {
                     .add_events(response.events)
                     .add_submessages(response.messages))
             }
-            ExecuteMsg::UpdateAdmin { address } => self.update_admin(deps.storage, info, address),
+            ExecuteMsg::UpdateAdmin { address } => {
+                let validated_address =
+                    CwCallService::validate_address(deps.api, address.as_str())?;
+                self.update_admin(deps.storage, info, validated_address)
+            }
             ExecuteMsg::RemoveAdmin {} => self.remove_admin(deps.storage, info),
         }
     }

--- a/contracts/cosmwasm-vm/cw-xcall/src/lib.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/src/lib.rs
@@ -40,8 +40,8 @@ use crate::{
 use common::types::message::CrossContractMessage::XCallMessage;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
-    attr, ensure, ensure_eq, entry_point, from_binary, to_binary, Addr, Binary, Coin, CosmosMsg,
-    Deps, DepsMut, Empty, Env, Event, Ibc3ChannelOpenResponse, IbcBasicResponse,
+    attr, ensure, ensure_eq, entry_point, from_binary, to_binary, Addr, Api, Binary, Coin,
+    CosmosMsg, Deps, DepsMut, Empty, Env, Event, Ibc3ChannelOpenResponse, IbcBasicResponse,
     IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse,
     IbcEndpoint, IbcMsg, IbcOrder, IbcPacket, IbcPacketAckMsg, IbcPacketReceiveMsg,
     IbcPacketTimeoutMsg, IbcReceiveResponse, IbcTimeout, IbcTimeoutBlock, MessageInfo, Never,

--- a/contracts/cosmwasm-vm/cw-xcall/src/types/address.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/src/types/address.rs
@@ -48,4 +48,7 @@ impl Address {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }

--- a/contracts/cosmwasm-vm/cw-xcall/tests/test_admin.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/tests/test_admin.rs
@@ -263,8 +263,9 @@ fn add_invalid_char_as_admin() {
     let mut mock_deps = deps();
 
     let mock_info = create_mock_info(&alice().to_string(), "umlg", 2000);
+    let mock_env = mock_env();
 
-    let contract = CwCallService::default();
+    let mut contract = CwCallService::default();
 
     contract
         .add_owner(
@@ -274,10 +275,13 @@ fn add_invalid_char_as_admin() {
         .unwrap();
 
     contract
-        .add_admin(
-            mock_deps.as_mut().storage,
+        .execute(
+            mock_deps.as_mut(),
+            mock_env,
             mock_info.clone(),
-            "*************".into(),
+            cw_xcall::msg::ExecuteMsg::SetAdmin {
+                address: "*************".into(),
+            },
         )
         .unwrap();
 }
@@ -288,8 +292,9 @@ fn update_admin_invalid_chars() {
     let mut mock_deps = deps();
 
     let mock_info = create_mock_info(&alice().to_string(), "umlg", 2000);
+    let mock_env = mock_env();
 
-    let contract = CwCallService::default();
+    let mut contract = CwCallService::default();
 
     contract
         .add_owner(
@@ -299,7 +304,14 @@ fn update_admin_invalid_chars() {
         .unwrap();
 
     contract
-        .add_admin(mock_deps.as_mut().storage, mock_info.clone(), admin_one())
+        .execute(
+            mock_deps.as_mut(),
+            mock_env.clone(),
+            mock_info.clone(),
+            cw_xcall::msg::ExecuteMsg::SetAdmin {
+                address: admin_one(),
+            },
+        )
         .unwrap();
 
     let result = contract.query_admin(mock_deps.as_ref().storage).unwrap();
@@ -307,10 +319,75 @@ fn update_admin_invalid_chars() {
     assert_eq!(result, admin_one());
 
     contract
-        .update_admin(
-            mock_deps.as_mut().storage,
+        .execute(
+            mock_deps.as_mut(),
+            mock_env,
             mock_info.clone(),
-            "*****%%%%%@@@###!1234hello".into(),
+            cw_xcall::msg::ExecuteMsg::UpdateAdmin {
+                address: "*****%%%%%@@@###!1234hello".into(),
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+#[should_panic(
+    expected = "Std(GenericErr { msg: \"Invalid input: human address too short for this mock implementation (must be >= 3).\" })"
+)]
+fn validate_address_add_admin_size_lessthan_3() {
+    let mut mock_deps = deps();
+
+    let mock_info = create_mock_info(&alice().to_string(), "umlg", 2000);
+    let mock_env = mock_env();
+
+    let mut contract = CwCallService::default();
+
+    contract
+        .add_owner(
+            mock_deps.as_mut().storage,
+            Address::from(&mock_info.sender.to_string()),
+        )
+        .unwrap();
+
+    contract
+        .execute(
+            mock_deps.as_mut(),
+            mock_env,
+            mock_info.clone(),
+            cw_xcall::msg::ExecuteMsg::SetAdmin {
+                address: "sm".into(),
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+#[should_panic(
+    expected = "Std(GenericErr { msg: \"Invalid input: human address too long for this mock implementation (must be <= 90).\" })"
+)]
+fn validate_address_add_admin_size_more_than_45() {
+    let mut mock_deps = deps();
+
+    let mock_info = create_mock_info(&alice().to_string(), "umlg", 2000);
+    let mock_env = mock_env();
+
+    let mut contract = CwCallService::default();
+
+    contract
+        .add_owner(
+            mock_deps.as_mut().storage,
+            Address::from(&mock_info.sender.to_string()),
+        )
+        .unwrap();
+
+    contract
+        .execute(
+            mock_deps.as_mut(),
+            mock_env,
+            mock_info.clone(),
+            cw_xcall::msg::ExecuteMsg::SetAdmin {
+                address: "eddiuo6lbp05golmz3rb5n7hbi4c5hhyh0rb1w6cslyjt5mhwd0chn3x254lyorpx4dzvrvsc9h2em44be2rj193dwe".into(),
+            },
         )
         .unwrap();
 }


### PR DESCRIPTION
## Description:

### Commit Message

```bash
fix: invalid chars cannot be added as the admin address
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
