### PR TITLE
feat: Require 0 timeout timestamp for outgoing packets

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics02/client/IBCClient.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics02/client/IBCClient.java
@@ -1,14 +1,11 @@
 package ibc.ics02.client;
 
 import ibc.icon.interfaces.ILightClient;
-import ibc.icon.score.util.ByteUtil;
 import ibc.icon.score.util.Logger;
 import ibc.icon.score.util.NullChecker;
 import ibc.icon.structs.messages.MsgCreateClient;
 import ibc.icon.structs.messages.MsgUpdateClient;
-import ibc.ics24.host.IBCCommitment;
 import ibc.ics24.host.IBCHost;
-import icon.proto.core.client.Height;
 import score.Address;
 import score.Context;
 
@@ -37,19 +34,19 @@ public class IBCClient extends IBCHost {
         btpNetworkId.set(clientId, msg.getBtpNetworkId());
 
         ILightClient client = getClient(clientId);
-        Map<String, byte[]> response = client.createClient(clientId, msg.getClientState(), msg.getConsensusState());
-        byte[] clientStateCommitment = response.get("clientStateCommitment");
-        byte[] consensusStateCommitment = response.get("consensusStateCommitment");
-        byte[] height = response.get("height");
+        client.createClient(clientId, msg.getClientState(), msg.getConsensusState());
+        // byte[] clientStateCommitment = response.get("clientStateCommitment");
+        // byte[] consensusStateCommitment = response.get("consensusStateCommitment");
+        // byte[] height = response.get("height");
 
-        byte[] clientKey = IBCCommitment.clientStateCommitmentKey(clientId);
-        Height updateHeight = Height.decode(height);
-        byte[] consensusKey = IBCCommitment.consensusStateCommitmentKey(clientId,
-                updateHeight.getRevisionNumber(),
-                updateHeight.getRevisionHeight());
+        // byte[] clientKey = IBCCommitment.clientStateCommitmentKey(clientId);
+        // Height updateHeight = Height.decode(height);
+        // byte[] consensusKey = IBCCommitment.consensusStateCommitmentKey(clientId,
+        //         updateHeight.getRevisionNumber(),
+        //         updateHeight.getRevisionHeight());
 
-        sendBTPMessage(clientId, ByteUtil.join(clientKey, clientStateCommitment));
-        sendBTPMessage(clientId, ByteUtil.join(consensusKey, consensusStateCommitment));
+        // sendBTPMessage(clientId, ByteUtil.join(clientKey, clientStateCommitment));
+        // sendBTPMessage(clientId, ByteUtil.join(consensusKey, consensusStateCommitment));
 
         return clientId;
     }
@@ -59,20 +56,20 @@ public class IBCClient extends IBCHost {
         ILightClient client = getClient(clientId);
 
         Map<String, byte[]>  response = client.updateClient(clientId, msg.getClientMessage());
-        byte[] clientStateCommitment = response.get("clientStateCommitment");
-        byte[] consensusStateCommitment = response.get("consensusStateCommitment");
-        byte[] height = response.get("height");
-        byte[] clientKey = IBCCommitment.clientStateCommitmentKey(clientId);
+        // byte[] clientStateCommitment = response.get("clientStateCommitment");
+        // byte[] consensusStateCommitment = response.get("consensusStateCommitment");
+        // byte[] height = response.get("height");
+        // byte[] clientKey = IBCCommitment.clientStateCommitmentKey(clientId);
 
-        Height updateHeight = Height.decode(height);
-        byte[] consensusKey = IBCCommitment.consensusStateCommitmentKey(clientId,
-                updateHeight.getRevisionNumber(),
-                updateHeight.getRevisionHeight());
+        // Height updateHeight = Height.decode(height);
+        // byte[] consensusKey = IBCCommitment.consensusStateCommitmentKey(clientId,
+        //         updateHeight.getRevisionNumber(),
+        //         updateHeight.getRevisionHeight());
 
-        sendBTPMessage(clientId, ByteUtil.join(clientKey, clientStateCommitment));
-        sendBTPMessage(clientId, ByteUtil.join(consensusKey, consensusStateCommitment));
+        // sendBTPMessage(clientId, ByteUtil.join(clientKey, clientStateCommitment));
+        // sendBTPMessage(clientId, ByteUtil.join(consensusKey, consensusStateCommitment));
 
-        return height;
+        return response.get("height");
     }
 
     private String generateClientIdentifier(String clientType) {

--- a/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
@@ -130,7 +130,6 @@ public class PacketTest extends TestBase {
         timeOutHeight.setRevisionHeight(BigInteger.valueOf(6000000));
         timeOutHeight.setRevisionNumber(BigInteger.ZERO);
         basePacket.setTimeoutHeight(timeOutHeight);
-        basePacket.setTimeoutTimestamp(BigInteger.valueOf(sm.getBlock().getTimestamp()*2));
     }
 
     @Test
@@ -210,22 +209,21 @@ public class PacketTest extends TestBase {
     }
 
     @Test
-    void sendPacket_toLowBlockTimestamp() {
+    void sendPacket_withTimestampTimeout() {
         // Arrange
         Height latestHeight = new Height();
         latestHeight.setRevisionHeight(BigInteger.ZERO);
         latestHeight.setRevisionNumber(BigInteger.ZERO);
-        BigInteger destinationChainBlockTimestamp = BigInteger.TEN;
-        basePacket.setTimeoutTimestamp(destinationChainBlockTimestamp.subtract(BigInteger.ONE));
+        basePacket.setTimeoutTimestamp(BigInteger.ONE);
         when(lightClient.mock.getLatestHeight(clientId)).thenReturn(latestHeight.encode());
         when(lightClient.mock.getTimestampAtHeight(clientId, latestHeight.encode()))
-                .thenReturn(destinationChainBlockTimestamp);
+                .thenReturn(BigInteger.ONE);
 
         // Act & Assert
-        String expectedErrorMessage = "receiving chain block timestamp >= packet timeout timestamp";
-        Executable toLowBlockTimestamp = () -> packet.invoke(owner, "_sendPacket", basePacket);
+        String expectedErrorMessage = "Timeout timestamps are not available, use timeout height instead";
+        Executable withTimestampTimeout = () -> packet.invoke(owner, "_sendPacket", basePacket);
         AssertionError e = assertThrows(AssertionError.class,
-                toLowBlockTimestamp);
+            withTimestampTimeout);
         assertTrue(e.getMessage().contains(expectedErrorMessage));
     }
 

--- a/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTest.java
@@ -116,8 +116,9 @@ public class IBCHandlerTest extends IBCHandlerTestBase {
     @Test
     void requestTimeoutPacket() throws Exception {
         establishCommunication();
-
-        requestTimeout(getBaseCounterPacket());
+        Packet packet = getBaseCounterPacket();
+        sm.getBlock().increase(timeoutHeight.longValue());
+        requestTimeout(packet);
     }
 
     @Test

--- a/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTestBase.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTestBase.java
@@ -68,6 +68,7 @@ public class IBCHandlerTestBase extends TestBase {
     protected Version baseVersion;
     protected String portId = "portId";
 
+    protected BigInteger timeoutHeight = BigInteger.valueOf(100);
     protected BigInteger nextRecvId = BigInteger.ONE;
     protected Height baseHeight;
 
@@ -466,7 +467,7 @@ public class IBCHandlerTestBase extends TestBase {
     protected Packet getBasePacket() {
         Height timeoutHeight = Height.newBuilder()
                 .setRevisionNumber(1)
-                .setRevisionHeight(sm.getBlock().getHeight() + 100).build();
+                .setRevisionHeight(sm.getBlock().getHeight() + this.timeoutHeight.longValue()).build();
 
         BigInteger nextPacketSeq = (BigInteger) handler.call("getNextSequenceSend", portId, channelId);
 
@@ -476,8 +477,7 @@ public class IBCHandlerTestBase extends TestBase {
                 .setSourceChannel(channelId)
                 .setDestinationPort(counterPartyPortId)
                 .setDestinationChannel(counterPartyChannelId)
-                .setTimeoutHeight(timeoutHeight)
-                .setTimeoutTimestamp(sm.getBlock().getTimestamp() * 2).build();
+                .setTimeoutHeight(timeoutHeight).build();
 
         when(lightClient.mock.getLatestHeight(clientId)).thenReturn(Height.getDefaultInstance().toByteArray());
         when(lightClient.mock.getTimestampAtHeight(any(String.class), any(byte[].class))).thenReturn(BigInteger.ONE);
@@ -488,7 +488,7 @@ public class IBCHandlerTestBase extends TestBase {
     protected Packet getBaseCounterPacket() {
         Height timeoutHeight = Height.newBuilder()
                 .setRevisionNumber(1)
-                .setRevisionHeight(sm.getBlock().getHeight() + 100).build();
+                .setRevisionHeight(sm.getBlock().getHeight() +  this.timeoutHeight.longValue()).build();
 
         Packet packet = Packet.newBuilder()
                 .setSequence(nextRecvId.longValue())
@@ -497,8 +497,7 @@ public class IBCHandlerTestBase extends TestBase {
                 .setSourceChannel(counterPartyChannelId)
                 .setSourcePort(counterPartyPortId)
                 .setData(ByteString.copyFrom(new byte[7]))
-                .setTimeoutHeight(timeoutHeight)
-                .setTimeoutTimestamp(sm.getBlock().getTimestamp() * 2).build();
+                .setTimeoutHeight(timeoutHeight).build();
 
         nextRecvId = nextRecvId.add(BigInteger.ONE);
 

--- a/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTestBase.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTestBase.java
@@ -82,8 +82,6 @@ public class IBCHandlerTestBase extends TestBase {
         lightClient = new MockContract<>(ILightClientScoreInterface.class, ILightClient.class, sm, owner);
         module = new MockContract<>(IIBCModuleScoreInterface.class, IIBCModule.class, sm, owner);
 
-        when(lightClient.mock.getClientState(any(String.class))).thenReturn(new byte[0]);
-
         prefix = MerklePrefix.newBuilder()
                 .setKeyPrefix(ByteString.copyFrom("ibc".getBytes())).build();
         baseVersion = Version.newBuilder()
@@ -104,12 +102,11 @@ public class IBCHandlerTestBase extends TestBase {
         msg.setBtpNetworkId(4);
 
         when(lightClient.mock.createClient(any(String.class), any(byte[].class), any(byte[].class)))
-                .thenReturn(Map.of(
-                    "clientStateCommitment", new byte[0],
-                    "consensusStateCommitment", new byte[0],
-                    "height",Height.getDefaultInstance().toByteArray()
-            ));
-;
+            .thenReturn(Map.of(
+                "clientStateCommitment", new byte[0],
+                "consensusStateCommitment", new byte[0],
+                "height",Height.getDefaultInstance().toByteArray()
+        ));
 
         // Act
         handler.invoke(owner, "createClient", msg);
@@ -117,7 +114,11 @@ public class IBCHandlerTestBase extends TestBase {
         // Assert
         verify(handlerSpy).CreateClient(clientIdCaptor.capture(), eq(msg.getClientState()));
         clientId = clientIdCaptor.getValue();
-    }
+
+        when(lightClient.mock.getLatestHeight(clientId)).thenReturn(new byte[0]);
+        when(lightClient.mock.getClientState(clientId)).thenReturn(new byte[0]);
+        when(lightClient.mock.getConsensusState(eq(clientId), any(byte[].class))).thenReturn(new byte[0]);
+   }
 
     void updateClient() {
         // Arrange

--- a/contracts/javascore/modules/mockapp/src/main/java/ibc/mockapp/MockApp.java
+++ b/contracts/javascore/modules/mockapp/src/main/java/ibc/mockapp/MockApp.java
@@ -56,11 +56,13 @@ public class MockApp implements IIBCModule {
         pct.setSourcePort(srcPort.get());
         pct.setSourceChannel(srcChan.get());
 
+        if (timeoutHeight.equals(BigInteger.ZERO)) {
+            timeoutHeight = BigInteger.valueOf(Context.getBlockHeight() + 100);
+        }
         Height hgt = new Height();
         hgt.setRevisionHeight(timeoutHeight);
         pct.setTimeoutHeight(hgt);
 
-        pct.setTimeoutTimestamp(timeoutTimestamp);
         Context.call(this.ibcHandler, "sendPacket", pct.encode());
     }
 


### PR DESCRIPTION
All packets sent from a counterparty using the ICON lightclient wont be able to use timestamps. So in order to be able to timeout we should require timeout height to be set and timeout timestamp to be zero.

## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
