### PR TITLE
feat: Only send client and consensus state when updating a connection

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics02/client/IBCClient.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics02/client/IBCClient.java
@@ -1,14 +1,11 @@
 package ibc.ics02.client;
 
 import ibc.icon.interfaces.ILightClient;
-import ibc.icon.score.util.ByteUtil;
 import ibc.icon.score.util.Logger;
 import ibc.icon.score.util.NullChecker;
 import ibc.icon.structs.messages.MsgCreateClient;
 import ibc.icon.structs.messages.MsgUpdateClient;
-import ibc.ics24.host.IBCCommitment;
 import ibc.ics24.host.IBCHost;
-import icon.proto.core.client.Height;
 import score.Address;
 import score.Context;
 
@@ -37,19 +34,19 @@ public class IBCClient extends IBCHost {
         btpNetworkId.set(clientId, msg.getBtpNetworkId());
 
         ILightClient client = getClient(clientId);
-        Map<String, byte[]> response = client.createClient(clientId, msg.getClientState(), msg.getConsensusState());
-        byte[] clientStateCommitment = response.get("clientStateCommitment");
-        byte[] consensusStateCommitment = response.get("consensusStateCommitment");
-        byte[] height = response.get("height");
+        client.createClient(clientId, msg.getClientState(), msg.getConsensusState());
+        // byte[] clientStateCommitment = response.get("clientStateCommitment");
+        // byte[] consensusStateCommitment = response.get("consensusStateCommitment");
+        // byte[] height = response.get("height");
 
-        byte[] clientKey = IBCCommitment.clientStateCommitmentKey(clientId);
-        Height updateHeight = Height.decode(height);
-        byte[] consensusKey = IBCCommitment.consensusStateCommitmentKey(clientId,
-                updateHeight.getRevisionNumber(),
-                updateHeight.getRevisionHeight());
+        // byte[] clientKey = IBCCommitment.clientStateCommitmentKey(clientId);
+        // Height updateHeight = Height.decode(height);
+        // byte[] consensusKey = IBCCommitment.consensusStateCommitmentKey(clientId,
+        //         updateHeight.getRevisionNumber(),
+        //         updateHeight.getRevisionHeight());
 
-        sendBTPMessage(clientId, ByteUtil.join(clientKey, clientStateCommitment));
-        sendBTPMessage(clientId, ByteUtil.join(consensusKey, consensusStateCommitment));
+        // sendBTPMessage(clientId, ByteUtil.join(clientKey, clientStateCommitment));
+        // sendBTPMessage(clientId, ByteUtil.join(consensusKey, consensusStateCommitment));
 
         return clientId;
     }
@@ -59,20 +56,20 @@ public class IBCClient extends IBCHost {
         ILightClient client = getClient(clientId);
 
         Map<String, byte[]>  response = client.updateClient(clientId, msg.getClientMessage());
-        byte[] clientStateCommitment = response.get("clientStateCommitment");
-        byte[] consensusStateCommitment = response.get("consensusStateCommitment");
-        byte[] height = response.get("height");
-        byte[] clientKey = IBCCommitment.clientStateCommitmentKey(clientId);
+        // byte[] clientStateCommitment = response.get("clientStateCommitment");
+        // byte[] consensusStateCommitment = response.get("consensusStateCommitment");
+        // byte[] height = response.get("height");
+        // byte[] clientKey = IBCCommitment.clientStateCommitmentKey(clientId);
 
-        Height updateHeight = Height.decode(height);
-        byte[] consensusKey = IBCCommitment.consensusStateCommitmentKey(clientId,
-                updateHeight.getRevisionNumber(),
-                updateHeight.getRevisionHeight());
+        // Height updateHeight = Height.decode(height);
+        // byte[] consensusKey = IBCCommitment.consensusStateCommitmentKey(clientId,
+        //         updateHeight.getRevisionNumber(),
+        //         updateHeight.getRevisionHeight());
 
-        sendBTPMessage(clientId, ByteUtil.join(clientKey, clientStateCommitment));
-        sendBTPMessage(clientId, ByteUtil.join(consensusKey, consensusStateCommitment));
+        // sendBTPMessage(clientId, ByteUtil.join(clientKey, clientStateCommitment));
+        // sendBTPMessage(clientId, ByteUtil.join(consensusKey, consensusStateCommitment));
 
-        return height;
+        return response.get("height");
     }
 
     private String generateClientIdentifier(String clientType) {

--- a/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTestBase.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTestBase.java
@@ -82,8 +82,6 @@ public class IBCHandlerTestBase extends TestBase {
         lightClient = new MockContract<>(ILightClientScoreInterface.class, ILightClient.class, sm, owner);
         module = new MockContract<>(IIBCModuleScoreInterface.class, IIBCModule.class, sm, owner);
 
-        when(lightClient.mock.getClientState(any(String.class))).thenReturn(new byte[0]);
-
         prefix = MerklePrefix.newBuilder()
                 .setKeyPrefix(ByteString.copyFrom("ibc".getBytes())).build();
         baseVersion = Version.newBuilder()
@@ -104,12 +102,11 @@ public class IBCHandlerTestBase extends TestBase {
         msg.setBtpNetworkId(4);
 
         when(lightClient.mock.createClient(any(String.class), any(byte[].class), any(byte[].class)))
-                .thenReturn(Map.of(
-                    "clientStateCommitment", new byte[0],
-                    "consensusStateCommitment", new byte[0],
-                    "height",Height.getDefaultInstance().toByteArray()
-            ));
-;
+            .thenReturn(Map.of(
+                "clientStateCommitment", new byte[0],
+                "consensusStateCommitment", new byte[0],
+                "height",Height.getDefaultInstance().toByteArray()
+        ));
 
         // Act
         handler.invoke(owner, "createClient", msg);
@@ -117,7 +114,11 @@ public class IBCHandlerTestBase extends TestBase {
         // Assert
         verify(handlerSpy).CreateClient(clientIdCaptor.capture(), eq(msg.getClientState()));
         clientId = clientIdCaptor.getValue();
-    }
+
+        when(lightClient.mock.getLatestHeight(clientId)).thenReturn(new byte[0]);
+        when(lightClient.mock.getClientState(clientId)).thenReturn(new byte[0]);
+        when(lightClient.mock.getConsensusState(eq(clientId), any(byte[].class))).thenReturn(new byte[0]);
+   }
 
     void updateClient() {
         // Arrange


### PR DESCRIPTION
Since we can't do multi height proofs in a simple way we need to provide relevant data needed by counter party for every connection update.

Client state and consensus states should only be needed to verify during connection establishment and not required after.

## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
