### PR TITLE
fix: hash packet data before creating packet commitment

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
@@ -407,7 +407,7 @@ public class IBCPacket extends IBCChannelHandshake {
                         packet.getTimeoutTimestamp().toByteArray(),
                         packet.getTimeoutHeight().getRevisionNumber().toByteArray(),
                         packet.getTimeoutHeight().getRevisionHeight().toByteArray(),
-                        packet.getData()));
+                        IBCCommitment.sha256(packet.getData())));
     }
 
     private boolean isZero(Height height) {

--- a/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
@@ -638,6 +638,6 @@ public class PacketTest extends TestBase {
                         packet.getTimeoutTimestamp().toByteArray(),
                         packet.getTimeoutHeight().getRevisionNumber().toByteArray(),
                         packet.getTimeoutHeight().getRevisionHeight().toByteArray(),
-                        packet.getData())));
+                        IBCCommitment.sha256(packet.getData()))));
     }
 }


### PR DESCRIPTION
## Description:
During implementation the wrong packet commitment format was used.
References:
https://github.com/cosmos/ibc-go/blob/fa10438afcbd77262148dfd9cfbbe76e6d45d873/modules/core/04-channel/types/packet.go#L19
https://github.com/cosmos/ibc/blob/main/spec/core/ics-004-channel-and-packet-semantics/README.md

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
