### PR TITLE
feat: implement lookup module by channel

### DIFF
--- a/contracts/cosmwasm-vm/cw-ibc-core/tests/channel/test_receive_packet.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/tests/channel/test_receive_packet.rs
@@ -3,6 +3,7 @@ use cosmwasm_std::IbcReceiveResponse;
 use ibc::core::ics03_connection::connection::Counterparty as ConnectionCounterparty;
 use ibc::core::ics03_connection::connection::State as ConnectionState;
 use ibc::core::ics04_channel::msgs::recv_packet::MsgRecvPacket;
+use ibc::core::ics04_channel::msgs::PacketMsg;
 use ibc::core::ics04_channel::packet::Receipt;
 use ibc::timestamp::Timestamp;
 use ibc_proto::ibc::core::channel::v1::MsgRecvPacket as RawMsgRecvPacket;
@@ -415,5 +416,37 @@ fn test_receive_packet_fail_missing_channel() {
 
     contract
         .validate_receive_packet(deps.as_mut(), info, &msg)
+        .unwrap();
+}
+
+#[test]
+fn test_lookup_module_packet() {
+    let mut deps = deps();
+    let ctx = CwIbcCoreContext::default();
+    let module_id =
+        ibc::core::ics26_routing::context::ModuleId::from_str("contractaddress").unwrap();
+    let msg = MsgRecvPacket::try_from(get_dummy_raw_msg_recv_packet(12)).unwrap();
+    ctx.store_module_by_port(
+        &mut deps.storage,
+        msg.packet.port_id_on_a.clone().into(),
+        module_id.clone(),
+    )
+    .unwrap();
+    let channel_msg = PacketMsg::Recv(msg);
+    let res = ctx.lookup_module_packet(&mut deps.storage, &channel_msg);
+
+    assert!(res.is_ok());
+    assert_eq!("contractaddress", res.unwrap().to_string())
+}
+
+#[test]
+#[should_panic(expected = "UnknownPort")]
+fn test_lookup_module_packet_fail() {
+    let mut deps = deps();
+    let ctx = CwIbcCoreContext::default();
+    let msg = MsgRecvPacket::try_from(get_dummy_raw_msg_recv_packet(12)).unwrap();
+    let channel_msg = PacketMsg::Recv(msg);
+
+    ctx.lookup_module_packet(&mut deps.storage, &channel_msg)
         .unwrap();
 }

--- a/contracts/cosmwasm-vm/cw-ibc-core/tests/test_port.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/tests/test_port.rs
@@ -1,7 +1,10 @@
 pub mod setup;
 use std::str::FromStr;
 
-use cw_ibc_core::{context::CwIbcCoreContext, keccak256, types::PortId};
+use cw_ibc_core::{
+    context::CwIbcCoreContext, ics04_channel::ChannelMsg, keccak256, types::PortId,
+    MsgChannelOpenInit,
+};
 use setup::*;
 
 #[test]
@@ -67,4 +70,35 @@ fn check_for_port_id() {
     let port_id = PortId::from_str("xcall");
 
     assert!(port_id.is_ok())
+}
+
+#[test]
+fn test_lookup_module_channel() {
+    let mut deps = deps();
+    let ctx = CwIbcCoreContext::default();
+    let module_id =
+        ibc::core::ics26_routing::context::ModuleId::from_str("contractaddress").unwrap();
+    let msg = MsgChannelOpenInit::try_from(get_dummy_raw_msg_chan_open_init(None)).unwrap();
+    ctx.store_module_by_port(
+        &mut deps.storage,
+        msg.port_id_on_a.clone().into(),
+        module_id.clone(),
+    )
+    .unwrap();
+    let channel_msg = ChannelMsg::OpenInit(msg);
+    let res = ctx.lookup_module_channel(&mut deps.storage, &channel_msg);
+
+    assert!(res.is_ok());
+    assert_eq!("contractaddress", res.unwrap().to_string())
+}
+
+#[test]
+#[should_panic(expected = "UnknownPort")]
+fn test_lookup_module_channel_fail() {
+    let mut deps = deps();
+    let ctx = CwIbcCoreContext::default();
+    let msg = MsgChannelOpenInit::try_from(get_dummy_raw_msg_chan_open_init(None)).unwrap();
+    let channel_msg = ChannelMsg::OpenInit(msg);
+    ctx.lookup_module_channel(&mut deps.storage, &channel_msg)
+        .unwrap();
 }


### PR DESCRIPTION
## Description:
As a developer, I want to be able to query the module by channel to retrieve the module address from the store, 

### Commit Message

```bash
feat: impelement lookup module by channel
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
