### PR TITLE
feat: implement bindport

### DIFF
--- a/contracts/cosmwasm-vm/cw-ibc-core/src/ics05_port/mod.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/src/ics05_port/mod.rs
@@ -1,9 +1,10 @@
 //! ICS 05: Port implementation specifies the allocation scheme used by modules to
 //! bind to uniquely named ports.
 pub mod port;
-use cosmwasm_std::Storage;
-use ibc::core::{ics05_port::error::PortError, ics26_routing::context::ModuleId};
-
-use crate::{context::CwIbcCoreContext, ContractError};
-use cw_common::types::PortId;
 use super::*;
+use crate::{context::CwIbcCoreContext, ContractError};
+use cosmwasm_std::Storage;
+use cw_common::types::PortId;
+use cw_common::IbcPortId;
+use ibc::core::ics04_channel::msgs::{ChannelMsg, PacketMsg};
+use ibc::core::{ics05_port::error::PortError, ics26_routing::context::ModuleId};

--- a/contracts/cosmwasm-vm/cw-ibc-core/src/ics05_port/mod.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/src/ics05_port/mod.rs
@@ -6,3 +6,4 @@ use ibc::core::{ics05_port::error::PortError, ics26_routing::context::ModuleId};
 
 use crate::{context::CwIbcCoreContext, ContractError};
 use cw_common::types::PortId;
+use super::*;

--- a/contracts/cosmwasm-vm/cw-ibc-core/src/ics05_port/port.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/src/ics05_port/port.rs
@@ -1,3 +1,4 @@
+use cw_common::IbcPortId;
 use ibc::core::ics04_channel::msgs::{ChannelMsg, PacketMsg};
 
 use super::*;
@@ -67,5 +68,27 @@ impl<'a> CwIbcCoreContext<'a> {
         };
         let module_id = self.lookup_module_by_port(store, port_id.clone().into())?;
         Ok(module_id)
+    }
+
+    pub fn bind_port(
+        &self,
+        store: &mut dyn Storage,
+        port_id: &IbcPortId,
+        address: String,
+    ) -> Result<(), ContractError> {
+        self.claim_capability(store, self.port_path(port_id), address)
+    }
+
+    pub fn channel_capability_path(
+        &self,
+        port_id: &IbcPortId,
+        channel_id: &IbcChannelId,
+    ) -> Vec<u8> {
+        let path = format!(
+            "ports/{}/channels/{}",
+            port_id.to_string(),
+            channel_id.to_string()
+        );
+        path.as_bytes().to_vec()
     }
 }

--- a/contracts/cosmwasm-vm/cw-ibc-core/src/ics05_port/port.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/src/ics05_port/port.rs
@@ -1,5 +1,4 @@
-use cw_common::IbcPortId;
-use ibc::core::ics04_channel::msgs::{ChannelMsg, PacketMsg};
+
 
 use super::*;
 

--- a/contracts/cosmwasm-vm/cw-ibc-core/tests/test_host.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/tests/test_host.rs
@@ -51,9 +51,6 @@ fn test_claim_capability() {
     contract
         .store_capability(&mut deps.storage, name.clone(), vec![address.clone()])
         .unwrap();
-    contract
-        .get_capability(&mut deps.storage, name.clone())
-        .unwrap();
     let result = contract.claim_capability(&mut deps.storage, name, address);
     assert_eq!(result.is_ok(), true)
 }

--- a/contracts/cosmwasm-vm/cw-ibc-core/tests/test_port.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/tests/test_port.rs
@@ -133,7 +133,7 @@ fn channel_capability_path() {
 }
 
 #[test]
-#[should_panic(expected = "CapabilityNotFound")]
+#[should_panic(expected = "KeyNotFound")]
 fn test_bind_port_fail() {
     let mut deps = deps();
     let ctx = CwIbcCoreContext::default();

--- a/contracts/cosmwasm-vm/cw-ibc-core/tests/test_port.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/tests/test_port.rs
@@ -1,9 +1,10 @@
 pub mod setup;
-use std::str::FromStr;
+use std::str::{from_utf8, FromStr};
 
 use cw_common::types::PortId;
 use cw_ibc_core::{
-    context::CwIbcCoreContext, ics04_channel::ChannelMsg, keccak256, MsgChannelOpenInit,
+    context::CwIbcCoreContext, ics04_channel::ChannelMsg, keccak256, IbcChannelId,
+    MsgChannelOpenInit,
 };
 use setup::*;
 
@@ -101,4 +102,45 @@ fn test_lookup_module_channel_fail() {
     let channel_msg = ChannelMsg::OpenInit(msg);
     ctx.lookup_module_channel(&mut deps.storage, &channel_msg)
         .unwrap();
+}
+
+#[test]
+fn test_bind_port() {
+    let mut deps = deps();
+    let ctx = CwIbcCoreContext::default();
+    let path = ctx.port_path(&PortId::default().ibc_port_id());
+    ctx.store_capability(&mut deps.storage, path.clone(), vec!["".to_string()])
+        .unwrap();
+    let res = ctx.bind_port(
+        &mut deps.storage,
+        &PortId::default().ibc_port_id(),
+        "ContractAddress".to_string(),
+    );
+    assert!(res.is_ok());
+    let expected = ctx.get_capability(&mut deps.storage, path);
+    assert!(expected.is_ok());
+    assert!(expected.unwrap().contains(&"ContractAddress".to_string()))
+}
+
+#[test]
+fn channel_capability_path() {
+    let ctx = CwIbcCoreContext::default();
+    let res =
+        ctx.channel_capability_path(&PortId::default().ibc_port_id(), &IbcChannelId::default());
+    let result = from_utf8(&res);
+    assert!(result.is_ok());
+    assert_eq!("ports/defaultPort/channels/channel-0", result.unwrap())
+}
+
+#[test]
+#[should_panic(expected = "CapabilityNotFound")]
+fn test_bind_port_fail() {
+    let mut deps = deps();
+    let ctx = CwIbcCoreContext::default();
+    ctx.bind_port(
+        &mut deps.storage,
+        &PortId::default().ibc_port_id(),
+        "ContractAddress".to_string(),
+    )
+    .unwrap();
 }


### PR DESCRIPTION
## Description:
As a developer, I want to implement the "bindport" functionality for the "port" module, so that I can allow clients to bind to a particular port and establish a connection with a corresponding port on another chain.

### Commit Message

```bash
feat: implement bindport
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
