### PR TITLE
feat: implement-port-capability-path

### DIFF
--- a/contracts/cosmwasm-vm/cw-ibc-core/tests/test_connection.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/tests/test_connection.rs
@@ -1345,6 +1345,7 @@ fn connection_open_confirm_validate_fails_of_connection_state_mismatch() {
         .connection_open_confirm(res_msg, deps.as_mut(), info)
         .unwrap();
 }
+
 #[test]
 #[should_panic(expected = "Std(NotFound { kind: \"alloc::vec::Vec<u8>\" })")]
 fn connection_check_open_init_validate_fails() {
@@ -1553,7 +1554,7 @@ fn connection_open_try_invalid_client_id_name_too_long() {
 fn connection_open_try_with_valid_client_id_with_special_chars() {
     let default_raw_try_msg = get_dummy_raw_msg_conn_open_try(1, 3);
     let try_msg = RawMsgConnectionOpenTry {
-        counterparty: Some (RawCounterparty{
+        counterparty: Some(RawCounterparty {
             client_id: "ClientId_".to_string(),
             ..get_dummy_raw_counterparty(Some(0))
         }),
@@ -1564,7 +1565,7 @@ fn connection_open_try_with_valid_client_id_with_special_chars() {
 }
 
 #[test]
-fn connection_open_try_empty_counterparty_versions(){
+fn connection_open_try_empty_counterparty_versions() {
     let default_raw_try_msg = get_dummy_raw_msg_conn_open_try(1, 3);
     let try_msg = RawMsgConnectionOpenTry {
         counterparty_versions: Vec::new(),
@@ -1575,10 +1576,13 @@ fn connection_open_try_empty_counterparty_versions(){
 }
 
 #[test]
-fn connection_open_try_invalid_proof_height_zero(){
+fn connection_open_try_invalid_proof_height_zero() {
     let default_raw_try_msg = get_dummy_raw_msg_conn_open_try(1, 3);
     let try_msg = RawMsgConnectionOpenTry {
-       proof_height: Some(Height { revision_number: 1, revision_height: 0 }),
+        proof_height: Some(Height {
+            revision_number: 1,
+            revision_height: 0,
+        }),
         ..default_raw_try_msg.clone()
     };
     let res_msg = MsgConnectionOpenTry::try_from(try_msg.clone());
@@ -1586,10 +1590,13 @@ fn connection_open_try_invalid_proof_height_zero(){
 }
 
 #[test]
-fn connection_open_try_invalid_consensus_height_zero(){
+fn connection_open_try_invalid_consensus_height_zero() {
     let default_raw_try_msg = get_dummy_raw_msg_conn_open_try(1, 3);
     let try_msg = RawMsgConnectionOpenTry {
-       consensus_height: Some(Height { revision_number: 1, revision_height: 0 }),
+        consensus_height: Some(Height {
+            revision_number: 1,
+            revision_height: 0,
+        }),
         ..default_raw_try_msg.clone()
     };
     let res_msg = MsgConnectionOpenTry::try_from(try_msg.clone());
@@ -1597,7 +1604,7 @@ fn connection_open_try_invalid_consensus_height_zero(){
 }
 
 #[test]
-fn connection_open_try_empty_proof(){
+fn connection_open_try_empty_proof() {
     let default_raw_try_msg = get_dummy_raw_msg_conn_open_try(1, 3);
     let try_msg = RawMsgConnectionOpenTry {
         proof_init: b"".to_vec(),
@@ -1609,7 +1616,7 @@ fn connection_open_try_empty_proof(){
 
 #[test]
 #[should_panic(expected = "Std(NotFound { kind: \"u64\" })")]
-fn connection_open_init_fails(){
+fn connection_open_init_fails() {
     let mut deps = deps();
 
     let message = RawMsgConnectionOpenInit {
@@ -1646,6 +1653,177 @@ fn connection_open_init_fails(){
             cl.unwrap(),
         )
         .unwrap();
-    contract.connection_open_init(deps.as_mut(), res_msg).unwrap();
-  
+    contract
+        .connection_open_init(deps.as_mut(), res_msg)
+        .unwrap();
 }
+
+#[test]
+#[should_panic(expected = "Std(NotFound { kind: \"alloc::vec::Vec<u8>\" })")]
+fn connection_open_ack_validate_fails_of_consensus_state() {
+    let mut deps = deps();
+    let info = create_mock_info("alice", "umlg", 2000);
+
+    let contract = CwIbcCoreContext::default();
+    contract
+        .connection_next_sequence_init(&mut deps.storage, u128::default().try_into().unwrap())
+        .unwrap();
+
+    let message = get_dummy_raw_msg_conn_open_ack(10, 10);
+
+    let res_msg = ibc::core::ics03_connection::msgs::conn_open_ack::MsgConnectionOpenAck::try_from(
+        message.clone(),
+    )
+    .unwrap();
+
+    let client_id = IbcClientId::default();
+    let client_state: ClientState = common::icon::icon::lightclient::v1::ClientState {
+        trusting_period: 2,
+        frozen_height: 0,
+        max_clock_drift: 5,
+        latest_height: 100,
+        network_section_hash: vec![1, 2, 3],
+        validators: vec!["hash".as_bytes().to_vec()],
+    }
+    .try_into()
+    .unwrap();
+
+    let light_client = Addr::unchecked("lightclient");
+    contract
+        .store_client_implementations(
+            &mut deps.storage,
+            client_id.clone().into(),
+            light_client.to_string(),
+        )
+        .unwrap();
+
+    let counterparty_prefix = ibc::core::ics23_commitment::commitment::CommitmentPrefix::try_from(
+        "hello".as_bytes().to_vec(),
+    )
+    .unwrap();
+    let counterparty_client_id = ClientId::from_str("counterpartyclient-1").unwrap();
+    let counter_party = ibc::core::ics03_connection::connection::Counterparty::new(
+        counterparty_client_id.ibc_client_id().clone(),
+        None,
+        counterparty_prefix.clone(),
+    );
+
+    let conn_end = ConnectionEnd::new(
+        ibc::core::ics03_connection::connection::State::Init,
+        IbcClientId::default().clone(),
+        counter_party.clone(),
+        vec![ibc::core::ics03_connection::version::Version::default()],
+        Duration::default(),
+    );
+    contract
+        .store_connection(
+            &mut deps.storage,
+            res_msg.conn_id_on_a.clone().into(),
+            conn_end.clone(),
+        )
+        .unwrap();
+
+    let client_state_bytes = to_vec(&client_state).unwrap();
+
+    contract
+        .store_client_state(&mut deps.storage, &client_id.clone(), client_state_bytes)
+        .unwrap();
+
+    contract
+        .connection_open_ack(info, deps.as_mut(), res_msg)
+        .unwrap();
+}
+
+#[test]
+#[should_panic(expected = "ConnectionMismatch")]
+fn connection_open_ack_validate_fails_of_connection_mismatch() {
+    let mut deps = deps();
+    let info = create_mock_info("alice", "umlg", 2000);
+
+    let contract = CwIbcCoreContext::default();
+    contract
+        .connection_next_sequence_init(&mut deps.storage, u128::default().try_into().unwrap())
+        .unwrap();
+
+    let message = get_dummy_raw_msg_conn_open_ack(10, 10);
+
+    let res_msg = ibc::core::ics03_connection::msgs::conn_open_ack::MsgConnectionOpenAck::try_from(
+        message.clone(),
+    )
+    .unwrap();
+
+    let client_id = IbcClientId::default();
+    let consenus_state: ConsensusState = common::icon::icon::lightclient::v1::ConsensusState {
+        message_root: "helloconnectionmessage".as_bytes().to_vec(),
+    }
+    .try_into()
+    .unwrap();
+    let client_state: ClientState = common::icon::icon::lightclient::v1::ClientState {
+        trusting_period: 2,
+        frozen_height: 0,
+        max_clock_drift: 5,
+        latest_height: 100,
+        network_section_hash: vec![1, 2, 3],
+        validators: vec!["hash".as_bytes().to_vec()],
+    }
+    .try_into()
+    .unwrap();
+
+    let light_client = Addr::unchecked("lightclient");
+    contract
+        .store_client_implementations(
+            &mut deps.storage,
+            client_id.clone().into(),
+            light_client.to_string(),
+        )
+        .unwrap();
+
+    let counterparty_prefix = ibc::core::ics23_commitment::commitment::CommitmentPrefix::try_from(
+        "hello".as_bytes().to_vec(),
+    )
+    .unwrap();
+    let counterparty_client_id = ClientId::from_str("counterpartyclient-1").unwrap();
+    let counter_party = ibc::core::ics03_connection::connection::Counterparty::new(
+        counterparty_client_id.ibc_client_id().clone(),
+        None,
+        counterparty_prefix.clone(),
+    );
+
+    let conn_end = ConnectionEnd::new(
+        ibc::core::ics03_connection::connection::State::Open,
+        IbcClientId::default().clone(),
+        counter_party.clone(),
+        vec![ibc::core::ics03_connection::version::Version::default()],
+        Duration::default(),
+    );
+    contract
+        .store_connection(
+            &mut deps.storage,
+            res_msg.conn_id_on_a.clone().into(),
+            conn_end.clone(),
+        )
+        .unwrap();
+
+    let client_state_bytes = to_vec(&client_state).unwrap();
+
+    contract
+        .store_client_state(&mut deps.storage, &client_id.clone(), client_state_bytes)
+        .unwrap();
+
+    let consenus_state = to_vec(&consenus_state).unwrap();
+
+    contract
+        .store_consensus_state(
+            &mut deps.storage,
+            &conn_end.client_id().clone().into(),
+            res_msg.proofs_height_on_b.clone(),
+            consenus_state,
+        )
+        .unwrap();
+
+    contract
+        .connection_open_ack(info, deps.as_mut(), res_msg)
+        .unwrap();
+}
+
+


### PR DESCRIPTION
## Description:

As a developer , I want to implement a port capability path so that I can easily establish connections and transfer data between different modules. I want to be able to create a port capability for my module, so that other modules can establish connections with my module and initiate data transfer. And also want to establish a connection with another module by providing its port capability path, so that I can initiate data transfer between the two modules.

### Commit Message

```bash
feat: implement port capability
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
