### PR TITLE
feat: convert BigInteger numbers to fixed 64 length bytes

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
@@ -2,6 +2,7 @@ package ibc.ics04.channel;
 
 import ibc.icon.interfaces.ILightClient;
 import ibc.icon.score.util.ByteUtil;
+import ibc.icon.score.util.Proto;
 import ibc.ics24.host.IBCCommitment;
 import icon.proto.core.channel.Channel;
 import icon.proto.core.channel.Packet;
@@ -236,7 +237,7 @@ public class IBCPacket extends IBCChannelHandshake {
 
             byte[] recvCommitmentKey = IBCCommitment.nextSequenceRecvCommitmentKey(packet.getDestinationPort(),
                     packet.getDestinationChannel());
-            byte[] recvCommitment = packet.getSequence().toByteArray();
+            byte[] recvCommitment = Proto.encodeFixed64(packet.getSequence());
             sendBTPMessage(connection.getClientId(), ByteUtil.join(recvCommitmentKey, recvCommitment));
         } else {
             Context.revert("unknown ordering type");
@@ -300,7 +301,7 @@ public class IBCPacket extends IBCChannelHandshake {
                     proofHeight,
                     proof,
                     nextRecvKey,
-                    nextSequenceRecv.toByteArray());
+                    Proto.encodeFixed64(nextSequenceRecv));
             channel.setState(Channel.State.STATE_CLOSED);
 
             byte[] encodedChannel = channel.encode();
@@ -399,9 +400,9 @@ public class IBCPacket extends IBCChannelHandshake {
     private byte[] createPacketCommitment(Packet packet) {
         return IBCCommitment.sha256(
                 ByteUtil.join(
-                        packet.getTimeoutTimestamp().toByteArray(),
-                        packet.getTimeoutHeight().getRevisionNumber().toByteArray(),
-                        packet.getTimeoutHeight().getRevisionHeight().toByteArray(),
+                        Proto.encodeFixed64(packet.getTimeoutTimestamp()),
+                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionNumber()),
+                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionHeight()),
                         IBCCommitment.sha256(packet.getData())));
     }
 

--- a/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import java.math.BigInteger;
 import java.util.List;
 
+import ibc.icon.score.util.Proto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -554,7 +555,7 @@ public class PacketTest extends TestBase {
 
         // Assert
         verify(packetSpy).sendBTPMessage(clientId,
-                ByteUtil.join(commitmentPath, basePacket.getSequence().toByteArray()));
+                ByteUtil.join(commitmentPath, Proto.encodeFixed64(basePacket.getSequence())));
     }
 
     @Test
@@ -618,7 +619,7 @@ public class PacketTest extends TestBase {
                 basePacket.getDestinationChannel());
         verify(lightClient.mock).verifyMembership(clientId, proofHeight.encode(),
                 baseConnection.getDelayPeriod(), BigInteger.ZERO,
-                proof, prefix.getKeyPrefix(), commitmentPath, basePacket.getSequence().toByteArray());
+                proof, prefix.getKeyPrefix(), commitmentPath, Proto.encodeFixed64(basePacket.getSequence()));
 
         byte[] packetCommitmentKey = IBCCommitment.packetCommitmentKey(basePacket.getSourcePort(),
                 basePacket.getSourceChannel(), basePacket.getSequence());
@@ -633,9 +634,9 @@ public class PacketTest extends TestBase {
     private byte[] createPacketCommitment(Packet packet) {
         return IBCCommitment.sha256(
                 ByteUtil.join(
-                        packet.getTimeoutTimestamp().toByteArray(),
-                        packet.getTimeoutHeight().getRevisionNumber().toByteArray(),
-                        packet.getTimeoutHeight().getRevisionHeight().toByteArray(),
+                        Proto.encodeFixed64(packet.getTimeoutTimestamp()),
+                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionNumber()),
+                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionHeight()),
                         IBCCommitment.sha256(packet.getData())));
     }
 }

--- a/contracts/javascore/score-util/src/main/java/ibc/icon/score/util/Proto.java
+++ b/contracts/javascore/score-util/src/main/java/ibc/icon/score/util/Proto.java
@@ -264,10 +264,20 @@ public class Proto {
         if (item.equals(BigInteger.ZERO)) {
             return new byte[0];
         }
-        long l = item.longValue();
         byte[] bs = new byte[9];
         bs[0] = (byte) (order << 3 | 1);
-        for (int i = 1; i < 9; i++) {
+        byte[] num = encodeFixed64(item);
+        System.arraycopy(num, 0, bs, 1, num.length);
+        return bs;
+    }
+
+    public static byte[] encodeFixed64(BigInteger item) {
+        byte[] bs = new byte[8];
+        if (item.equals(BigInteger.ZERO)) {
+            return bs;
+        }
+        long l = item.longValue();
+        for (int i = 0; i < 8; i++) {
             bs[i] = (byte) (l & 0xFF);
             l >>= 8;
         }


### PR DESCRIPTION
## Description:
In IBC handler all biginteger numbers are converted to 64 bit fixed length bytes. For proto it didn't like BigInteger.ZERO being converted to 64 bit. Tests were failing in tendermint light client. Thus only IBC handler sends 0 as 64 bit bytes.

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
