### PR TITLE
feat: remove double hashing, use sha256 only

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
@@ -56,7 +56,7 @@ public class IBCPacket extends IBCChannelHandshake {
                 packet.getSourceChannel(),
                 packet.getSequence());
 
-        byte[] packetCommitment = IBCCommitment.keccak256(createPacketCommitment(packet));
+        byte[] packetCommitment = createPacketCommitment(packet);
         commitments.set(packetCommitmentKey, packetCommitment);
 
         sendBTPMessage(connection.getClientId(),
@@ -97,7 +97,7 @@ public class IBCPacket extends IBCChannelHandshake {
 
         byte[] commitmentPath = IBCCommitment.packetCommitmentPath(packet.getSourcePort(),
                 packet.getSourceChannel(), packet.getSequence());
-        byte[] commitmentBytes = IBCCommitment.keccak256(createPacketCommitment(packet));
+        byte[] commitmentBytes = createPacketCommitment(packet);
 
         verifyPacketCommitment(
                 connection,
@@ -141,7 +141,7 @@ public class IBCPacket extends IBCChannelHandshake {
         byte[] ackCommitmentKey = IBCCommitment.packetAcknowledgementCommitmentKey(destinationPortId,
                 destinationChannel, sequence);
         Context.require(commitments.get(ackCommitmentKey) == null, "acknowledgement for packet already exists");
-        byte[] ackCommitment = IBCCommitment.keccak256(IBCCommitment.sha256(acknowledgement));
+        byte[] ackCommitment = IBCCommitment.sha256(acknowledgement);
         commitments.set(ackCommitmentKey, ackCommitment);
         sendBTPMessage(connection.getClientId(), ByteUtil.join(ackCommitmentKey, ackCommitment));
 
@@ -167,7 +167,7 @@ public class IBCPacket extends IBCChannelHandshake {
                 packet.getSourceChannel(), packet.getSequence());
         byte[] packetCommitment = commitments.get(packetCommitmentKey);
         Context.require(packetCommitment != null, "packet commitment not found");
-        byte[] commitment = IBCCommitment.keccak256(createPacketCommitment(packet));
+        byte[] commitment = createPacketCommitment(packet);
 
         Context.require(IBCCommitment.equals(packetCommitment, commitment), "commitment byte[] are not equal");
 
@@ -267,7 +267,7 @@ public class IBCPacket extends IBCChannelHandshake {
                 packet.getSourceChannel(), packet.getSequence());
         byte[] packetCommitment = commitments.get(packetCommitmentKey);
         Context.require(packetCommitment != null, "packet commitment not found");
-        byte[] commitment = IBCCommitment.keccak256(createPacketCommitment(packet));
+        byte[] commitment = createPacketCommitment(packet);
 
         Context.require(IBCCommitment.equals(packetCommitment, commitment), "commitment byte[] are not equal");
 

--- a/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
@@ -481,7 +481,7 @@ public class PacketTest extends TestBase {
         byte[] ackCommitmentKey = IBCCommitment.packetAcknowledgementCommitmentKey(baseCounterparty.getPortId(),
                 baseCounterparty.getChannelId(), sequence);
 
-        byte[] expectedCommitment = IBCCommitment.keccak256(IBCCommitment.sha256(acknowledgement));
+        byte[] expectedCommitment = IBCCommitment.sha256(acknowledgement);
         verify(packetSpy).sendBTPMessage(clientId, ByteUtil.join(ackCommitmentKey, expectedCommitment));
     }
 
@@ -631,11 +631,11 @@ public class PacketTest extends TestBase {
     }
 
     private byte[] createPacketCommitment(Packet packet) {
-        return IBCCommitment.keccak256(IBCCommitment.sha256(
+        return IBCCommitment.sha256(
                 ByteUtil.join(
                         packet.getTimeoutTimestamp().toByteArray(),
                         packet.getTimeoutHeight().getRevisionNumber().toByteArray(),
                         packet.getTimeoutHeight().getRevisionHeight().toByteArray(),
-                        IBCCommitment.sha256(packet.getData()))));
+                        IBCCommitment.sha256(packet.getData())));
     }
 }


### PR DESCRIPTION
## Description:

Remove double hashing as requested by relay team

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
