### PR TITLE
feat: add getBindPorts method

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCHost.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCHost.java
@@ -23,6 +23,9 @@ public class IBCHost extends IBCStore {
     public void claimCapability(byte[] name, Address addr) {
         ArrayDB<Address> capability = capabilities.at(name);
         int capabilitiesCount = capability.size();
+        if (capabilitiesCount == 0) {
+            portIds.add(name);
+        }
         for (int i = 0; i < capabilitiesCount; i++) {
             Context.require(!capability.get(i).equals(addr), TAG + "Capability already claimed");
         }

--- a/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCStore.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCStore.java
@@ -7,8 +7,10 @@ import ibc.icon.score.util.NullChecker;
 import ibc.ics05.port.ModuleManager;
 import score.*;
 import score.annotation.External;
+import scorex.util.ArrayList;
 
 import java.math.BigInteger;
+import java.util.List;
 
 public abstract class IBCStore extends ModuleManager implements IIBCHost {
     private static final String COMMITMENTS = "commitments";
@@ -22,6 +24,7 @@ public abstract class IBCStore extends ModuleManager implements IIBCHost {
     private static final String NEXT_SEQUENCE_ACKNOWLEDGEMENTS = "nextSequenceAcknowledgements";
     private static final String PACKET_RECEIPTS = "packetReceipts";
     private static final String CAPABILITIES = "capabilities";
+    private static final String PORT_IDS = "portIds";
     private static final String EXPECTED_TIME_PER_BLOCK = "expectedTimePerBlock";
     private static final String NEXT_CLIENT_SEQUENCE = "nextClientSequence";
     private static final String NEXT_CONNECTION_SEQUENCE = "nextConnectionSequence";
@@ -54,7 +57,7 @@ public abstract class IBCStore extends ModuleManager implements IIBCHost {
             .newBranchDB(PACKET_RECEIPTS, Boolean.class);
 
     public static final BranchDB<byte[], ArrayDB<Address>> capabilities = Context.newBranchDB(CAPABILITIES, Address.class);
-
+    public static final ArrayDB<byte[]> portIds = Context.newArrayDB(PORT_IDS, byte[].class);
     // Host Parameters
     public static final VarDB<BigInteger> expectedTimePerBlock = Context.newVarDB(EXPECTED_TIME_PER_BLOCK, BigInteger.class);
 
@@ -126,6 +129,16 @@ public abstract class IBCStore extends ModuleManager implements IIBCHost {
         }
 
         return capability;
+    }
+
+    @External(readonly = true)
+    public List<byte[]> getBindPorts() {
+        List<byte[]> ports = new ArrayList<>();
+        final int size = portIds.size();
+        for (int i = 0; i < size; i++) {
+            ports.add(i, portIds.get(i));
+        }
+        return ports;
     }
 
     @External(readonly = true)


### PR DESCRIPTION
## Description:

portIds stores all the keys for the capabilities db. Each time a unique key is found, it's added in the portid database. Uniqueness is determined if capabilities hash 0 address for that key. There doesn't seem to be method to remove capability, thus it's assumed that the address size for any key will not be reduced to zero which may hamper the uniqueness assumption.

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
