### PR TITLE
feat: allow option to choose between little endian and big endian encoding

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
@@ -237,7 +237,7 @@ public class IBCPacket extends IBCChannelHandshake {
 
             byte[] recvCommitmentKey = IBCCommitment.nextSequenceRecvCommitmentKey(packet.getDestinationPort(),
                     packet.getDestinationChannel());
-            byte[] recvCommitment = Proto.encodeFixed64(packet.getSequence());
+            byte[] recvCommitment = Proto.encodeFixed64(packet.getSequence(), false);
             sendBTPMessage(connection.getClientId(), ByteUtil.join(recvCommitmentKey, recvCommitment));
         } else {
             Context.revert("unknown ordering type");
@@ -301,7 +301,7 @@ public class IBCPacket extends IBCChannelHandshake {
                     proofHeight,
                     proof,
                     nextRecvKey,
-                    Proto.encodeFixed64(nextSequenceRecv));
+                    Proto.encodeFixed64(nextSequenceRecv, false));
             channel.setState(Channel.State.STATE_CLOSED);
 
             byte[] encodedChannel = channel.encode();
@@ -400,9 +400,9 @@ public class IBCPacket extends IBCChannelHandshake {
     private byte[] createPacketCommitment(Packet packet) {
         return IBCCommitment.sha256(
                 ByteUtil.join(
-                        Proto.encodeFixed64(packet.getTimeoutTimestamp()),
-                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionNumber()),
-                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionHeight()),
+                        Proto.encodeFixed64(packet.getTimeoutTimestamp(), false),
+                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionNumber(), false),
+                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionHeight(), false),
                         IBCCommitment.sha256(packet.getData())));
     }
 

--- a/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
@@ -555,7 +555,7 @@ public class PacketTest extends TestBase {
 
         // Assert
         verify(packetSpy).sendBTPMessage(clientId,
-                ByteUtil.join(commitmentPath, Proto.encodeFixed64(basePacket.getSequence())));
+                ByteUtil.join(commitmentPath, Proto.encodeFixed64(basePacket.getSequence(), false)));
     }
 
     @Test
@@ -619,7 +619,7 @@ public class PacketTest extends TestBase {
                 basePacket.getDestinationChannel());
         verify(lightClient.mock).verifyMembership(clientId, proofHeight.encode(),
                 baseConnection.getDelayPeriod(), BigInteger.ZERO,
-                proof, prefix.getKeyPrefix(), commitmentPath, Proto.encodeFixed64(basePacket.getSequence()));
+                proof, prefix.getKeyPrefix(), commitmentPath, Proto.encodeFixed64(basePacket.getSequence(), false));
 
         byte[] packetCommitmentKey = IBCCommitment.packetCommitmentKey(basePacket.getSourcePort(),
                 basePacket.getSourceChannel(), basePacket.getSequence());
@@ -634,9 +634,9 @@ public class PacketTest extends TestBase {
     private byte[] createPacketCommitment(Packet packet) {
         return IBCCommitment.sha256(
                 ByteUtil.join(
-                        Proto.encodeFixed64(packet.getTimeoutTimestamp()),
-                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionNumber()),
-                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionHeight()),
+                        Proto.encodeFixed64(packet.getTimeoutTimestamp(), false),
+                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionNumber(), false),
+                        Proto.encodeFixed64(packet.getTimeoutHeight().getRevisionHeight(), false),
                         IBCCommitment.sha256(packet.getData())));
     }
 }

--- a/contracts/javascore/score-util/src/main/java/ibc/icon/score/util/Proto.java
+++ b/contracts/javascore/score-util/src/main/java/ibc/icon/score/util/Proto.java
@@ -261,20 +261,27 @@ public class Proto {
         }
         byte[] bs = new byte[9];
         bs[0] = (byte) (order << 3 | 1);
-        byte[] num = encodeFixed64(item);
+        byte[] num = encodeFixed64(item, true);
         System.arraycopy(num, 0, bs, 1, num.length);
         return bs;
     }
 
-    public static byte[] encodeFixed64(BigInteger item) {
+    public static byte[] encodeFixed64(BigInteger item, boolean littleEndian) {
         byte[] bs = new byte[8];
         if (item.equals(BigInteger.ZERO)) {
             return bs;
         }
         long l = item.longValue();
-        for (int i = 0; i < 8; i++) {
-            bs[i] = (byte) (l & 0xFF);
-            l >>= 8;
+        if (littleEndian) {
+            for (int i = 0; i < 8; i++) {
+                bs[i] = (byte) (l & 0xFF);
+                l >>= 8;
+            }
+        } else {
+            for (int i = 7; i >= 0; i--) {
+                bs[i] = (byte) (l & 0xFF);
+                l >>= 8;
+            }
         }
 
         return bs;

--- a/contracts/javascore/score-util/src/test/java/ibc/icon/score/util/ProtoTest.java
+++ b/contracts/javascore/score-util/src/test/java/ibc/icon/score/util/ProtoTest.java
@@ -1,0 +1,18 @@
+package ibc.icon.score.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static ibc.icon.score.util.StringUtil.bytesToHex;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProtoTest {
+
+    @Test
+    void encodeFixed64() {
+        BigInteger num = BigInteger.valueOf(858);
+        assertEquals("5a03000000000000", bytesToHex(Proto.encodeFixed64(num, true)));
+        assertEquals("000000000000035a", bytesToHex(Proto.encodeFixed64(num, false)));
+    }
+}


### PR DESCRIPTION
## Description:
Allow option to choose between little endian and big endian encoding

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have run the unit tests
- [X] I only have one commit (if not, squash them into one commit).
- [X] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
