### PR TITLE
feat: Add storage prefix argument to create client

### DIFF
--- a/contracts/javascore/ibc/src/intTest/java/ibc/core/integration/IBCIntegrationTest.java
+++ b/contracts/javascore/ibc/src/intTest/java/ibc/core/integration/IBCIntegrationTest.java
@@ -90,6 +90,7 @@ public class IBCIntegrationTest implements ScoreIntegrationTest {
         msg.setConsensusState(new byte[0]);
         msg.setClientState(new byte[0]);
         msg.setBtpNetworkId(networkId);
+        msg.setStoragePrefix(new byte[0]);
 
         IIBCClientScoreClient client = getClientInterface(owner);
         var consumer = client.CreateClient((logs) -> {clientID = logs.get(0).getIdentifier();}, null);

--- a/contracts/javascore/ibc/src/main/java/ibc/ics02/client/IBCClient.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics02/client/IBCClient.java
@@ -34,7 +34,7 @@ public class IBCClient extends IBCHost {
         btpNetworkId.set(clientId, msg.getBtpNetworkId());
 
         ILightClient client = getClient(clientId);
-        client.createClient(clientId, msg.getClientState(), msg.getConsensusState());
+        client.createClient(clientId, msg.getClientState(), msg.getConsensusState(), msg.getStoragePrefix());
         // byte[] clientStateCommitment = response.get("clientStateCommitment");
         // byte[] consensusStateCommitment = response.get("consensusStateCommitment");
         // byte[] height = response.get("height");

--- a/contracts/javascore/ibc/src/test/java/ibc/ics02/client/ClientTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics02/client/ClientTest.java
@@ -89,6 +89,7 @@ public class ClientTest extends TestBase {
         msg.setConsensusState(new byte[2]);
         msg.setClientState(new byte[3]);
         msg.setBtpNetworkId(4);
+        msg.setStoragePrefix(new byte[4]);
         String expectedClientId = msg.getClientType() + "-0";
 
         // Act
@@ -97,7 +98,7 @@ public class ClientTest extends TestBase {
 
        // Assert
         assertEquals(BigInteger.ONE, client.call("getNextClientSequence"));
-        verify(lightClient.mock).createClient(expectedClientId, msg.getClientState(), msg.getConsensusState());
+        verify(lightClient.mock).createClient(expectedClientId, msg.getClientState(), msg.getConsensusState(), msg.getStoragePrefix());
     }
 
     @Test

--- a/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTestBase.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics25/handler/IBCHandlerTestBase.java
@@ -101,8 +101,9 @@ public class IBCHandlerTestBase extends TestBase {
         msg.setConsensusState(new byte[0]);
         msg.setClientType(clientType);
         msg.setBtpNetworkId(4);
+        msg.setStoragePrefix(new byte[0]);
 
-        when(lightClient.mock.createClient(any(String.class), any(byte[].class), any(byte[].class)))
+        when(lightClient.mock.createClient(any(String.class), any(byte[].class), any(byte[].class), any(byte[].class)))
                 .thenReturn(Map.of(
                         "clientStateCommitment", new byte[0],
                         "consensusStateCommitment", new byte[0],

--- a/contracts/javascore/lib/src/main/java/ibc/icon/interfaces/ILightClient.java
+++ b/contracts/javascore/lib/src/main/java/ibc/icon/interfaces/ILightClient.java
@@ -1,6 +1,7 @@
 package ibc.icon.interfaces;
 
 import foundation.icon.score.client.ScoreInterface;
+import score.annotation.Optional;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -15,7 +16,7 @@ public interface ILightClient {
      * createClient creates a new client with the given state. If succeeded, it returns a commitment for the initial
      * state.
      */
-    Map<String, byte[]> createClient(String clientId, byte[] clientStateBytes, byte[] consensusStateBytes);
+    Map<String, byte[]> createClient(String clientId, byte[] clientStateBytes, byte[] consensusStateBytes, @Optional byte[] _storagePrefix);
 
     /**
      * getTimestampAtHeight returns the timestamp of the consensus state at the given height.

--- a/contracts/javascore/lib/src/main/java/ibc/icon/structs/messages/MsgCreateClient.java
+++ b/contracts/javascore/lib/src/main/java/ibc/icon/structs/messages/MsgCreateClient.java
@@ -5,6 +5,7 @@ public class MsgCreateClient {
     private byte[] clientState;
     private byte[] consensusState;
     private int btpNetworkId;
+    private byte[] storagePrefix;
 
     public String getClientType() {
         return clientType;
@@ -38,4 +39,11 @@ public class MsgCreateClient {
         this.btpNetworkId = btpNetworkId;
     }
 
+    public byte[] getStoragePrefix() {
+        return storagePrefix;
+    }
+
+    public void setStoragePrefix(byte[] storagePrefix) {
+        this.storagePrefix = storagePrefix;
+    }
 }

--- a/contracts/javascore/lightclients/mockclient/src/main/java/ibc/mockclient/MockClient.java
+++ b/contracts/javascore/lightclients/mockclient/src/main/java/ibc/mockclient/MockClient.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import score.Context;
 import score.annotation.External;
+import score.annotation.Optional;
 import ibc.icon.interfaces.ILightClient;
 import icon.proto.core.client.Height;
 
@@ -42,10 +43,10 @@ public class MockClient implements ILightClient {
     }
 
     @External
-    public Map<String, byte[]> createClient(String clientId, byte[] clientStateBytes, byte[] consensusStateBytes) {
+    public Map<String, byte[]> createClient(String clientId, byte[] clientStateBytes, byte[] consensusStateBytes, @Optional byte[] _storagePrefix) {
         return Map.of(
             "clientStateCommitment", IBCCommitment.keccak256(clientStateBytes),
-            "consensusStateCommitment", IBCCommitment.keccak256(consensusStateBytes),  
+            "consensusStateCommitment", IBCCommitment.keccak256(consensusStateBytes),
             "height", new Height().encode()
         );
     }
@@ -54,7 +55,7 @@ public class MockClient implements ILightClient {
     public Map<String, byte[]> updateClient(String clientId, byte[] clientMessageBytes) {
         return Map.of(
             "clientStateCommitment", IBCCommitment.keccak256(clientMessageBytes),
-            "consensusStateCommitment", IBCCommitment.keccak256(clientMessageBytes),  
+            "consensusStateCommitment", IBCCommitment.keccak256(clientMessageBytes),
             "height", new Height().encode()
         );
     }

--- a/contracts/javascore/lightclients/tendermint/build.gradle
+++ b/contracts/javascore/lightclients/tendermint/build.gradle
@@ -29,7 +29,7 @@ test {
 }
 
 jacocoTestReport {
-    dependsOn(test, ':ibc:test', ':ibc:compileTestJava', ':mockclient:compileJava', ':mockclient:test', ':ibc:jacocoTestReport', ':mockapp:compileJava', ':mockapp:test', ':lib:test', ':proto-util:compileJava', ':proto-util:test', ':score-util:test')
+    dependsOn(test, ':ibc:test', ':ibc:compileTestJava', ':mockclient:compileJava', ':mockclient:test', ':ibc:jacocoTestReport', ':mockapp:compileJava', ':mockapp:test', ':mock-dapp:compileJava',':mock-dapp:test', ':lib:test', ':proto-util:compileJava', ':proto-util:test', ':score-util:test')
     doNotTrackState("Disable state tracking")
     reports {
         html {

--- a/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/LightClientTestBase.java
+++ b/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/LightClientTestBase.java
@@ -152,7 +152,7 @@ public class LightClientTestBase extends TestBase {
                 .setNextValidatorsHash(tmHeader.getSignedHeader().getHeader().getNextValidatorsHash()).build();
 
         client.invoke(ibcHandler, "createClient", clientId, clientState.toByteArray(),
-                consensusState.toByteArray());
+                consensusState.toByteArray(), new byte[0]);
     }
 
     protected void updateClient(int blockOrder, int referenceBlock) throws Exception {

--- a/contracts/javascore/xcall/src/intTest/java/ibc/xcall/integration/XCallIntegrationTest.java
+++ b/contracts/javascore/xcall/src/intTest/java/ibc/xcall/integration/XCallIntegrationTest.java
@@ -86,6 +86,7 @@ public class XCallIntegrationTest implements ScoreIntegrationTest {
         msg.setConsensusState(new byte[0]);
         msg.setClientState(new byte[0]);
         msg.setBtpNetworkId(networkId);
+        msg.setStoragePrefix(new byte[0]);
 
         IIBCClientScoreClient client = getClientInterface(owner);
         var consumer = client.CreateClient((logs) -> {clientID = logs.get(0).getIdentifier();}, null);


### PR DESCRIPTION
To allow contract specific prefix for the lightclients we introduce a new client specific variable that is prefixed to the path before doing membership or non membership proofs

## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
