### PR TITLE
feat: Implememt xCall abstraction for archway in E2E test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ gradle.properties
 .classpath
 .settings
 **/bin/
+**/pkg/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/test/chains/icon/localnet.go
+++ b/test/chains/icon/localnet.go
@@ -565,7 +565,8 @@ func (c *IconLocalnet) QueryContract(ctx context.Context, contractAddress, metho
 
 	// get query msg
 	queryMsg := c.GetQueryParam(methodName)
-	output, err := c.getFullNode().QueryContract(ctx, contractAddress, queryMsg, "")
+	output, err := c.getFullNode().QueryContract(ctx, contractAddress, queryMsg, params)
+
 	chains.Response = output
 	fmt.Printf("Response is : %s \n", output)
 	return ctx, err

--- a/test/e2e/config.yaml
+++ b/test/e2e/config.yaml
@@ -50,4 +50,4 @@ chains:
       client: "$BASE_PATH/artifacts/cw_icon_light_client.wasm"
       xcall: "$BASE_PATH/artifacts/cw_xcall_app.wasm"
       connection: "$BASE_PATH/artifacts/cw_xcall_ibc_connection.wasm"
-      dapp: "$BASE_PATH/artifacts/cw_mock_dapp.wasm"
+      dapp: "$BASE_PATH/artifacts/cw_mock_dapp_multi.wasm"


### PR DESCRIPTION
Implement xCall abstractions for cosmwasm chains, xCall is not currently working so details about implementation might change once it is completed

## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
