### PR TITLE
feat: Update xCall and IBC connection to lates spec and update spec

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCStore.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCStore.java
@@ -155,6 +155,11 @@ public abstract class IBCStore extends ModuleManager implements IIBCHost {
     }
 
     @External(readonly = true)
+    public byte[] getLatestHeight(String clientId) {
+        return getClient(clientId).getLatestHeight(clientId);
+    }
+
+    @External(readonly = true)
     public byte[] getClientState(String clientId) {
         return getClient(clientId).getClientState(clientId);
     }

--- a/contracts/javascore/lib/src/main/java/ibc/icon/interfaces/IIBCHost.java
+++ b/contracts/javascore/lib/src/main/java/ibc/icon/interfaces/IIBCHost.java
@@ -54,6 +54,9 @@ public interface IIBCHost {
     BigInteger getNextChannelSequence();
 
     @External(readonly = true)
+    byte[] getLatestHeight(String clientId);
+
+    @External(readonly = true)
     byte[] getClientState(String clientId);
 
     @External(readonly = true)

--- a/contracts/javascore/modules/mock-dapp-multi-protocol/src/main/java/ibc/xcall/sample/dapp/MultiProtocolSampleDapp.java
+++ b/contracts/javascore/modules/mock-dapp-multi-protocol/src/main/java/ibc/xcall/sample/dapp/MultiProtocolSampleDapp.java
@@ -78,7 +78,7 @@ public class MultiProtocolSampleDapp implements CallServiceReceiver {
     private BigInteger _sendCallMessage(BigInteger value, String to, byte[] data, byte[] rollback) {
         try {
             String net = NetworkAddress.valueOf(to).net();
-            return Context.call(BigInteger.class, value, this.callSvc, "sendCallMessage", to, new String[]{source.get(net)}, new String[]{destination.get(net)}, data, rollback);
+            return Context.call(BigInteger.class, value, this.callSvc, "sendCallMessage", to, data, rollback, new String[]{source.get(net)}, new String[]{destination.get(net)});
         } catch (UserRevertedException e) {
             // propagate the error code to the caller
             Context.revert(e.getCode(), "UserReverted");

--- a/contracts/javascore/xcall-connection/build.gradle
+++ b/contracts/javascore/xcall-connection/build.gradle
@@ -60,8 +60,7 @@ deployJar {
     parameters {
         arg('_xCall', "$xCallMultiProtocol")
         arg('_ibc', "$ibcCore")
-        arg('_nid', '0x1.ICON')
-        arg('_timeoutHeight', '0x3e8')
+        arg('port', "mock")
     }
 }
 

--- a/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/IBCConnection.java
+++ b/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/IBCConnection.java
@@ -157,11 +157,13 @@ public class IBCConnection {
         BigInteger unclaimedFees = unclaimedPacketFees.at(nid).getOrDefault(relayer, BigInteger.ZERO);
         unclaimedPacketFees.at(nid).set(relayer, unclaimedFees.add(msg.getFee()));
 
-        if (msg.getSn().compareTo(BigInteger.ZERO) > 0) {
-            incomingPackets.at(packet.getDestinationChannel()).set(msg.getSn(), packet.getSequence());
-        } else if (msg.getSn().equals(BigInteger.valueOf(-1))) {
+        if (msg.getSn() == null)  {
             Context.transfer(new Address(msg.getData()), msg.getFee());
             return new byte[0];
+        }
+
+        if (msg.getSn().compareTo(BigInteger.ZERO) > 0) {
+            incomingPackets.at(packet.getDestinationChannel()).set(msg.getSn(), packet.getSequence());
         }
 
         Context.call(xCall.get(), "handleMessage", nid, msg.getSn(), msg.getData());
@@ -316,7 +318,7 @@ public class IBCConnection {
         String channel = channels.get(nid);
         BigInteger seqNum = (BigInteger) Context.call(ibc.get(), "getNextSequenceSend", PORT, channel);
 
-        Message msg = new Message(BigInteger.ONE.negate(), amount, address);
+        Message msg = new Message(null, amount, address);
         Packet pct = new Packet();
 
         pct.setSequence(seqNum);

--- a/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/IBCConnection.java
+++ b/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/IBCConnection.java
@@ -20,7 +20,7 @@ package ibc.xcall.connection;
 import java.math.BigInteger;
 
 import icon.proto.core.channel.Channel.Counterparty;
-import icon.proto.core.channel.Channel;
+import icon.proto.core.channel.Channel.Order;
 import icon.proto.core.channel.Packet;
 import icon.proto.core.client.Height;
 import score.Address;
@@ -32,27 +32,37 @@ import score.annotation.External;
 import score.annotation.Payable;
 
 public class IBCConnection {
-    public static final String PORT = "mock";
+    public static String PORT = "mock";
     protected final VarDB<Address> ibc = Context.newVarDB("ibcHandler", Address.class);
     protected final VarDB<Address> xCall = Context.newVarDB("callService", Address.class);
-    protected final VarDB<String> networkId = Context.newVarDB("networkId", String.class);
     protected final VarDB<Address> admin = Context.newVarDB("admin", Address.class);
 
-    protected final VarDB<BigInteger> timeoutHeight = Context.newVarDB("timeoutHeight", BigInteger.class);
+    protected final BranchDB<String, DictDB<String, String>> configuredNetworkIds =  Context.newBranchDB("configuredNetworkIds", String.class);
+    protected final DictDB<String, String> configuredClients = Context.newDictDB("configuredClients", String.class);
+    protected final DictDB<String, BigInteger> configuredTimeoutHeight = Context.newDictDB("configuredTimeoutHeight", BigInteger.class);
+
+    protected final DictDB<String, String> lightClients = Context.newDictDB("lightClients", String.class);
+    protected final DictDB<String, BigInteger> timeoutHeights = Context.newDictDB("timeoutHeights", BigInteger.class);
 
     protected final DictDB<String, String> channels = Context.newDictDB("channels", String.class);
-    protected final DictDB<String, String> counterPartyNetworkId = Context.newDictDB("counterPartyNetworkId", String.class);
-    protected final DictDB<String, String> destinationChannel = Context.newDictDB("destinationChannel", String.class);
+    protected final DictDB<String, String> networkIds = Context.newDictDB("counterPartyNetworkId", String.class);
+    protected final DictDB<String, String> destinationPort = Context.newDictDB("destinationChannel", String.class);
+    protected final DictDB<String, String> destinationChannel = Context.newDictDB("destinationPort", String.class);
 
     protected final BranchDB<String, DictDB<BigInteger, BigInteger>> incomingPackets = Context.newBranchDB("incomingPackets", BigInteger.class);
     protected final BranchDB<String, DictDB<BigInteger, BigInteger>> outgoingPackets = Context.newBranchDB("outgoingPackets", BigInteger.class);
 
-    public IBCConnection(Address _xCall, Address _ibc, String _nid, BigInteger _timeoutHeight) {
+    protected final DictDB<String, BigInteger> sendPacketFee = Context.newDictDB("sendPacketFee", BigInteger.class);
+    protected final DictDB<String, BigInteger> ackFee = Context.newDictDB("ackFee", BigInteger.class);
+
+    protected final BranchDB<String, DictDB<BigInteger, BigInteger>> unclaimedAckFees = Context.newBranchDB("unclaimedAckFees", BigInteger.class);
+    protected final BranchDB<String, DictDB<Address, BigInteger>> unclaimedPacketFees = Context.newBranchDB("unclaimedPacketFees", BigInteger.class);
+
+    public IBCConnection(Address _xCall, Address _ibc, String port) {
         ibc.set(_ibc);
         xCall.set(_xCall);
-        networkId.set(_nid);
-        admin.set(Context.getOwner());
-        this.timeoutHeight.set(_timeoutHeight);
+        admin.set(Context.getCaller());
+        PORT = port;
     }
 
     private void checkCallerOrThrow(Address caller, String errMsg) {
@@ -63,13 +73,16 @@ public class IBCConnection {
         checkCallerOrThrow(ibc.get(), "Only IBCHandler allowed");
     }
 
-
     private void onlyXCall() {
         checkCallerOrThrow(xCall.get(), "Only XCall allowed");
     }
 
     private void onlyAdmin() {
         checkCallerOrThrow(admin.get(), "Only Admin allowed");
+    }
+
+    public BigInteger getValue() {
+        return Context.getValue();
     }
 
     @External
@@ -79,111 +92,160 @@ public class IBCConnection {
     }
 
     @External
-    public void configureChannel(String channelId, String counterpartyNid) {
+    public void setFee(String nid, BigInteger packetFee, BigInteger ackFee) {
         onlyAdmin();
+        sendPacketFee.set(nid, packetFee);
+        this.ackFee.set(nid, ackFee);
+    }
+
+    @External
+    public void configureConnection(String connectionId, String portId, String counterpartyNid, String clientId, BigInteger timeoutHeight) {
+        onlyAdmin();
+        Context.require(configuredNetworkIds.at(connectionId).get(portId) == null);
         Context.require(channels.get(counterpartyNid) == null);
-        Context.require(destinationChannel.get(channelId) != null);
-        channels.set(counterpartyNid, channelId);
-        counterPartyNetworkId.set(channelId, counterpartyNid);
+        configuredNetworkIds.at(connectionId).set(portId, counterpartyNid);
+        configuredClients.set(connectionId, clientId);
+        configuredTimeoutHeight.set(connectionId, timeoutHeight);
     }
 
     @Payable
     @External
-    public BigInteger sendMessage(String _to, String _svc, BigInteger _sn, byte[] _msg) {
+    public void sendMessage(String _to, String _svc, BigInteger _sn, byte[] _msg) {
         onlyXCall();
+        String channel = channels.get(_to);
         if (_sn.compareTo(BigInteger.ZERO) < 0) {
-           return writeAcknowledgement(_to, _sn.negate(), _msg);
+           writeAcknowledgement(_to, _sn.negate(), _msg);
+           return;
         }
 
-        // TODO fee logic
-        String channel = channels.get(_to);
-        String destinationChannel = this.destinationChannel.get(channel);
         BigInteger seqNum = (BigInteger) Context.call(ibc.get(), "getNextSequenceSend", PORT, channel);
+        BigInteger packetFee = sendPacketFee.getOrDefault(_to, BigInteger.ZERO);
+        BigInteger _ackFee = BigInteger.ZERO;
+        if (_sn.compareTo(BigInteger.ZERO) > 0 ) {
+            _ackFee = ackFee.getOrDefault(_to, BigInteger.ZERO);
+            unclaimedAckFees.at(_to).set(seqNum, _ackFee);
+        }
+
+        Context.require(packetFee.add(_ackFee).compareTo(getValue()) >= 0, "Fee is not sufficient");
         if (!_sn.equals(BigInteger.ZERO)) {
             outgoingPackets.at(channel).set(seqNum, _sn);
         }
 
-        Height hgt = new Height();
-        BigInteger timeoutHeight = BigInteger.valueOf(Context.getBlockHeight()).add(this.timeoutHeight.get());
-        hgt.setRevisionHeight(timeoutHeight);
-        //TODO use correct revision height
-        hgt.setRevisionNumber(BigInteger.ZERO);
-
+        Message msg = new Message(_sn, packetFee, _msg);
         Packet pct = new Packet();
         pct.setSequence(seqNum);
-        pct.setData(new Message(_sn, _msg).toBytes());
+        pct.setData(msg.toBytes());
         pct.setSourcePort(PORT);
         pct.setSourceChannel(channel);
-        pct.setDestinationPort(PORT);
-        pct.setDestinationChannel(destinationChannel);
-        pct.setTimeoutHeight(hgt);
+        pct.setDestinationPort(destinationPort.get(channel));
+        pct.setDestinationChannel(destinationChannel.get(channel));
+        pct.setTimeoutHeight(getTimeoutHeight(channel));
         pct.setTimeoutTimestamp(BigInteger.ZERO);
 
         Context.call(ibc.get(), "sendPacket", (Object)pct.encode());
-        return BigInteger.ONE;
     }
 
     @External
     public byte[] onRecvPacket(byte[] calldata, Address relayer) {
         onlyIBCHandler();
+
         Packet packet = Packet.decode(calldata);
         Message msg = Message.fromBytes(packet.getData());
-        String nid = counterPartyNetworkId.get(packet.getDestinationChannel());
+        String nid = networkIds.get(packet.getDestinationChannel());
         Context.require(nid != null);
-        if (!msg.getSn().equals(BigInteger.ZERO)) {
+
+        BigInteger unclaimedFees = unclaimedPacketFees.at(nid).getOrDefault(relayer, BigInteger.ZERO);
+        unclaimedPacketFees.at(nid).set(relayer, unclaimedFees.add(msg.getFee()));
+
+        if (msg.getSn().compareTo(BigInteger.ZERO) > 0) {
             incomingPackets.at(packet.getDestinationChannel()).set(msg.getSn(), packet.getSequence());
+        } else if (msg.getSn().equals(BigInteger.valueOf(-1))) {
+            Context.transfer(new Address(msg.getData()), msg.getFee());
+            return new byte[0];
         }
 
-        Context.call(xCall.get(), "handleBTPMessage", nid, "xcall", msg.getSn(), msg.getData());
+        Context.call(xCall.get(), "handleMessage", nid, msg.getSn(), msg.getData());
         return new byte[0];
     }
 
     @External
     public void onAcknowledgementPacket(byte[] calldata, byte[] acknowledgement, Address relayer) {
         onlyIBCHandler();
+
         Packet packet = Packet.decode(calldata);
         BigInteger sn = outgoingPackets.at(packet.getSourceChannel()).get(packet.getSequence());
         outgoingPackets.at(packet.getSourceChannel()).set(packet.getSequence(), null);
-        String nid = counterPartyNetworkId.get(packet.getSourceChannel());
+        String nid = networkIds.get(packet.getSourceChannel());
+
         Context.require(nid != null);
         Context.require(sn != null);
-        Context.call(xCall.get(), "handleBTPMessage", nid, "xcall", sn, acknowledgement);
+
+        Context.transfer(relayer, unclaimedAckFees.at(nid).get(packet.getSequence()));
+        unclaimedAckFees.at(nid).set(packet.getSequence(), null);
+
+        Context.call(xCall.get(), "handleMessage", nid, sn, acknowledgement);
     }
 
     @External
     public void onTimeoutPacket(byte[] calldata, Address relayer) {
         onlyIBCHandler();
         Packet packet = Packet.decode(calldata);
+        Message msg = Message.fromBytes(packet.getData());
         BigInteger sn = outgoingPackets.at(packet.getSourceChannel()).get(packet.getSequence());
         outgoingPackets.at(packet.getSourceChannel()).set(packet.getSequence(), null);
+        String nid = networkIds.get(packet.getSourceChannel());
 
         Context.require(sn != null);
-        Context.call(xCall.get(), "handleBTPError", "", "xcall", sn, -1, "Timeout");
+
+        BigInteger fee = msg.getFee();
+        fee = fee.add(unclaimedAckFees.at(nid).get(packet.getSequence()));
+        unclaimedAckFees.at(nid).set(packet.getSequence(), null);
+
+        Context.call(xCall.get(), "handleError", sn, -1, "Timeout");
+        Context.transfer(relayer, fee);
     }
 
-    private BigInteger writeAcknowledgement(String _to, BigInteger _sn, byte[] _msg) {
+    private void writeAcknowledgement(String _to, BigInteger _sn, byte[] _msg) {
         String channel = channels.get(_to);
         Packet pct = new Packet();
-        pct.setSequence(incomingPackets.at(channel).get(_sn));
+        BigInteger sequenceNumber = incomingPackets.at(channel).get(_sn);
         incomingPackets.at(channel).set(_sn, null);
 
+        pct.setSequence(sequenceNumber);
         pct.setDestinationPort(PORT);
         pct.setDestinationChannel(channel);
 
         Context.call(ibc.get(), "writeAcknowledgement", (Object)pct.encode(), _msg);
-        return BigInteger.ONE;
+    }
+
+    private Height getTimeoutHeight(String channelId) {
+        byte[] heightBytes = Context.call(byte[].class, ibc.get(), "getLatestHeight", lightClients.get(channelId));
+        Height height = Height.decode(heightBytes);
+        height.setRevisionHeight(height.getRevisionHeight().add(timeoutHeights.get(channelId)));
+        return height;
     }
 
     @External
     public void onChanOpenInit(int order, String[] connectionHops, String portId, String channelId,
             byte[] counterpartyPb, String version) {
         onlyIBCHandler();
-        // TODO verify order
+
+        Context.require(order == Order.ORDER_UNORDERED, "Channel order has to be unordered");
         // TODO verify version
 
-        Context.require(portId.equals(PORT));
+        String connectionId = connectionHops[0];
         Counterparty counterparty = Counterparty.decode(counterpartyPb);
-        Context.require(counterparty.getPortId().equals(PORT));
+        String counterpartyPortId = counterparty.getPortId();
+        String counterPartyNid = configuredNetworkIds.at(connectionId).get(counterpartyPortId);
+        Context.require(portId == PORT, "Invalid port");
+        Context.require(counterPartyNid != null, "Connection not configured");
+        Context.require(channels.get(counterPartyNid) == null, "Network id is already configured");
+
+        lightClients.set(channelId, configuredClients.get(connectionId));
+        destinationPort.set(channelId, counterpartyPortId);
+        networkIds.set(channelId, counterPartyNid);
+        timeoutHeights.set(channelId, configuredTimeoutHeight.get(connectionId));
+        channels.set(counterPartyNid, channelId);
     }
 
     @External
@@ -191,13 +253,22 @@ public class IBCConnection {
         byte[] counterpartyPb, String version, String counterpartyVersion) {
         onlyIBCHandler();
 
-        // TODO verify order
+        Context.require(order == Order.ORDER_UNORDERED, "Channel order has to be unordered");
         // TODO verify version
 
-        Context.require(portId.equals(PORT));
+        String connectionId = connectionHops[0];
         Counterparty counterparty = Counterparty.decode(counterpartyPb);
-        Context.require(counterparty.getPortId().equals(PORT));
+        String counterpartyPortId = counterparty.getPortId();
+        String counterPartyNid = configuredNetworkIds.at(connectionId).get(counterpartyPortId);
+        Context.require(portId == PORT, "Invalid port");
+        Context.require(counterPartyNid != null, "Connection not configured");
+        Context.require(channels.get(counterPartyNid) == null, "Network id is already configured");
+        lightClients.set(channelId, configuredClients.get(connectionId));
+        destinationPort.set(channelId, counterpartyPortId);
         destinationChannel.set(channelId, counterparty.getChannelId());
+        channels.set(counterPartyNid, channelId);
+        networkIds.set(channelId, counterPartyNid);
+        timeoutHeights.set(channelId, configuredTimeoutHeight.get(connectionId));
     }
 
     @External
@@ -227,10 +298,42 @@ public class IBCConnection {
         Context.revert("CannotCloseChannel");
     }
 
-
     @External(readonly = true)
     public BigInteger getFee(String _to, boolean _response) {
-        return BigInteger.ZERO;
+        BigInteger fee =sendPacketFee.getOrDefault(_to, BigInteger.ZERO);
+        if (_response) {
+            fee = fee.add(ackFee.getOrDefault(_to, BigInteger.ZERO));
+        }
+
+        return fee;
+    }
+
+    @External
+    public void claimFees(String nid, byte[] address) {
+        BigInteger amount = getUnclaimedFees(nid, Context.getCaller());
+        unclaimedPacketFees.at(nid).set(Context.getCaller(), null);
+        Context.require(amount.compareTo(BigInteger.ZERO) > 0, "No fees available");
+        String channel = channels.get(nid);
+        BigInteger seqNum = (BigInteger) Context.call(ibc.get(), "getNextSequenceSend", PORT, channel);
+
+        Message msg = new Message(BigInteger.ONE.negate(), amount, address);
+        Packet pct = new Packet();
+
+        pct.setSequence(seqNum);
+        pct.setData(msg.toBytes());
+        pct.setSourcePort(PORT);
+        pct.setSourceChannel(channel);
+        pct.setDestinationPort(destinationPort.get(channel));
+        pct.setDestinationChannel(destinationChannel.get(channel));
+        pct.setTimeoutHeight(getTimeoutHeight(channel));
+        pct.setTimeoutTimestamp(BigInteger.ZERO);
+
+        Context.call(ibc.get(), "sendPacket", (Object)pct.encode());
+    }
+
+    @External
+    public BigInteger getUnclaimedFees(String nid, Address relayer) {
+        return unclaimedPacketFees.at(nid).getOrDefault(relayer, BigInteger.ZERO);
     }
 
 }

--- a/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/IBCConnection.java
+++ b/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/IBCConnection.java
@@ -239,7 +239,7 @@ public class IBCConnection {
         Counterparty counterparty = Counterparty.decode(counterpartyPb);
         String counterpartyPortId = counterparty.getPortId();
         String counterPartyNid = configuredNetworkIds.at(connectionId).get(counterpartyPortId);
-        Context.require(portId == PORT, "Invalid port");
+        Context.require(portId.equals(PORT), "Invalid port");
         Context.require(counterPartyNid != null, "Connection not configured");
         Context.require(channels.get(counterPartyNid) == null, "Network id is already configured");
 
@@ -262,7 +262,7 @@ public class IBCConnection {
         Counterparty counterparty = Counterparty.decode(counterpartyPb);
         String counterpartyPortId = counterparty.getPortId();
         String counterPartyNid = configuredNetworkIds.at(connectionId).get(counterpartyPortId);
-        Context.require(portId == PORT, "Invalid port");
+        Context.require(portId.equals(PORT), "Invalid port");
         Context.require(counterPartyNid != null, "Connection not configured");
         Context.require(channels.get(counterPartyNid) == null, "Network id is already configured");
         lightClients.set(channelId, configuredClients.get(connectionId));

--- a/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/ICallservice.java
+++ b/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/ICallservice.java
@@ -19,7 +19,7 @@ public interface ICallservice {
      * @param _msg Bytes ( serialized bytes of ServiceMessage )
      */
     @External
-    void handleBTPMessage(String _from, String _svc, BigInteger _sn, byte[] _msg);
+    void handleMessage(String _from, BigInteger _sn, byte[] _msg);
 
     /**
      * Handle the error on delivering the message.
@@ -32,5 +32,5 @@ public interface ICallservice {
      * @param _msg String ( message of the error )
      */
     @External
-    void handleBTPError(String _src, String _svc, BigInteger _sn, long _code, String _msg);
+    void handleError( BigInteger _sn, long _code, String _msg);
 }

--- a/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/Message.java
+++ b/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/Message.java
@@ -25,10 +25,12 @@ import score.ObjectWriter;
 
 public class Message {
     private final BigInteger sn;
+    private final BigInteger fee;
     private final byte[] data;
 
-    public Message(BigInteger sn, byte[] data) {
+    public Message(BigInteger sn, BigInteger fee, byte[] data) {
         this.sn = sn;
+        this.fee = fee;
         this.data = data;
     }
 
@@ -36,13 +38,18 @@ public class Message {
         return sn;
     }
 
+    public BigInteger getFee() {
+        return fee;
+    }
+
     public byte[] getData() {
         return data;
     }
 
     public static void writeObject(ObjectWriter w, Message m) {
-        w.beginList(2);
+        w.beginList(3);
         w.write(m.sn);
+        w.write(m.fee);
         w.writeNullable(m.data);
         w.end();
     }
@@ -50,8 +57,9 @@ public class Message {
     public static Message readObject(ObjectReader r) {
         r.beginList();
         Message m = new Message(
-                r.readBigInteger(),
-                r.readNullable(byte[].class)
+            r.readBigInteger(),
+            r.readBigInteger(),
+            r.readNullable(byte[].class)
         );
         r.end();
         return m;

--- a/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/Message.java
+++ b/contracts/javascore/xcall-connection/src/main/java/ibc/xcall/connection/Message.java
@@ -48,7 +48,7 @@ public class Message {
 
     public static void writeObject(ObjectWriter w, Message m) {
         w.beginList(3);
-        w.write(m.sn);
+        w.writeNullable(m.sn);
         w.write(m.fee);
         w.writeNullable(m.data);
         w.end();
@@ -57,7 +57,7 @@ public class Message {
     public static Message readObject(ObjectReader r) {
         r.beginList();
         Message m = new Message(
-            r.readBigInteger(),
+            r.readNullable(BigInteger.class),
             r.readBigInteger(),
             r.readNullable(byte[].class)
         );

--- a/contracts/javascore/xcall-connection/src/test/java/ibc/xcall/connection/IBCConnectionTest.java
+++ b/contracts/javascore/xcall-connection/src/test/java/ibc/xcall/connection/IBCConnectionTest.java
@@ -3,6 +3,7 @@ package ibc.xcall.connection;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -293,7 +294,7 @@ public class IBCConnectionTest extends IBCConnectionTestBase {
         Message msg = Message.fromBytes(packet.getData());
         assertArrayEquals(relayer.getAddress().toByteArray(), msg.getData());
         assertEquals(fee, msg.getFee());
-        assertEquals(BigInteger.ONE.negate(), msg.getSn());
+        assertNull(msg.getSn());
         assertEquals(BigInteger.ZERO, connection.call("getUnclaimedFees", defaultCounterpartyNid, relayer.getAddress()));
     }
 
@@ -310,7 +311,7 @@ public class IBCConnectionTest extends IBCConnectionTestBase {
 
         Packet pct = new Packet();
         pct.setSequence(seq);
-        pct.setData(new Message(BigInteger.ONE.negate(), fee, relayer.getAddress().toByteArray()).toBytes());
+        pct.setData(new Message(null, fee, relayer.getAddress().toByteArray()).toBytes());
         pct.setSourcePort(defaultCounterpartyPort);
         pct.setSourceChannel(defaultCounterpartyChannel);
         pct.setDestinationPort(IBCConnection.PORT);

--- a/contracts/javascore/xcall-connection/src/test/java/ibc/xcall/connection/IBCConnectionTestBase.java
+++ b/contracts/javascore/xcall-connection/src/test/java/ibc/xcall/connection/IBCConnectionTestBase.java
@@ -1,80 +1,92 @@
 package ibc.xcall.connection;
 
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
+import java.math.BigInteger;
+
+import org.mockito.Mockito;
 
 import com.iconloop.score.test.Account;
 import com.iconloop.score.test.Score;
 import com.iconloop.score.test.ServiceManager;
 import com.iconloop.score.test.TestBase;
-import foundation.icon.btp.xcall.CSMessage;
-import foundation.icon.btp.xcall.CSMessageRequest;
-import foundation.icon.btp.xcall.CSMessageResponse;
+
 import ibc.icon.interfaces.IIBCHandler;
 import ibc.icon.interfaces.IIBCHandlerScoreInterface;
 import ibc.icon.test.MockContract;
 import icon.proto.core.channel.Channel;
-import icon.proto.core.channel.Packet;
-import icon.proto.core.client.Height;
-import java.math.BigInteger;
-import java.util.List;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
-import score.Context;
 
 public class IBCConnectionTestBase extends TestBase {
 
     protected final ServiceManager sm = getServiceManager();
-    protected final Account owner = sm.createAccount();
+    protected final Account owner = sm.createAccount(1000);
     protected final Account relayer = sm.createAccount();
 
     protected Score connection;
+    protected static String port = "PORT";
     protected static String nid = "0x2.ICON";
     protected static int ORDER = Channel.Order.ORDER_UNORDERED;
-    protected static BigInteger timeoutHeight = BigInteger.valueOf(100);
+    protected static BigInteger packetFee = BigInteger.valueOf(100);
+    protected static BigInteger ackFee = BigInteger.valueOf(50);
+
+    protected static String defaultClientId = "clientId";
+    protected static String defaultConnectionId = "connectionId";
+    protected static String defaultChannel = "channel-1";
+    protected static String defaultCounterpartyPort = "counterpartyPort";
+    protected static String defaultCounterpartyChannel = "channel-2";
+    protected static String defaultCounterpartyNid = "0x1.ETH";
+    protected static BigInteger defaultTimeoutHeight = BigInteger.TEN;
 
     protected MockContract<ICallservice> xcall;
     protected MockContract<IIBCHandler> ibc;
+    protected IBCConnection connectionSpy;
 
     public void setup() throws Exception {
         xcall = new MockContract<>(ICallserviceScoreInterface.class, ICallservice.class, sm, owner);
         ibc = new MockContract<>(IIBCHandlerScoreInterface.class, IIBCHandler.class, sm, owner);
 
-        connection = sm.deploy(owner, IBCConnection.class, xcall.getAddress(), ibc.getAddress(), nid, timeoutHeight);
+        connection = sm.deploy(owner, IBCConnection.class, xcall.getAddress(), ibc.getAddress(), port);
+        connection.invoke(owner, "setFee", defaultCounterpartyNid, packetFee, ackFee);
+        connectionSpy = (IBCConnection) Mockito.spy(connection.getInstance());
+        connection.setInstance(connectionSpy);
     }
 
-    public void channelOpenInit(String channelId) {
+    public void channelOpenInit(String connectionId, String counterpartyPort, String channelId) {
         Channel.Counterparty counterparty = new Channel.Counterparty();
-        counterparty.setPortId(IBCConnection.PORT);
+        counterparty.setPortId(counterpartyPort);
         counterparty.setChannelId("");
-        connection.invoke(ibc.account, "onChanOpenInit", ORDER,  new String[]{"TODO"}, IBCConnection.PORT, channelId, counterparty.encode(), "version-TODO");
+        connection.invoke(ibc.account, "onChanOpenInit", ORDER,  new String[]{connectionId}, port, channelId, counterparty.encode(), "version-TODO");
     }
 
-    public void channelOpenTry(String channelId, String counterpartyChannelId) {
+    public void channelOpenTry(String connectionId, String counterpartyPort, String channelId, String counterpartyChannelId) {
         Channel.Counterparty counterparty = new Channel.Counterparty();
-        counterparty.setPortId(IBCConnection.PORT);
+        counterparty.setPortId(counterpartyPort);
         counterparty.setChannelId(counterpartyChannelId);
-        connection.invoke(ibc.account, "onChanOpenTry", ORDER,  new String[]{"TODO"}, IBCConnection.PORT, channelId, counterparty.encode(), "version-TODO", "version-TODO");
+        connection.invoke(ibc.account, "onChanOpenTry", ORDER,  new String[]{connectionId}, port, channelId, counterparty.encode(), "version-TODO", "version-TODO");
     }
 
     public void channelOpenAck(String channelId, String counterpartyChannelId) {
-        connection.invoke(ibc.account, "onChanOpenAck", IBCConnection.PORT, channelId, counterpartyChannelId,  "version-TODO");
+        connection.invoke(ibc.account, "onChanOpenAck", port, channelId, counterpartyChannelId,  "version-TODO");
     }
 
     public void channelOpenConfirm(String channelId) {
-        connection.invoke(ibc.account, "onChanOpenConfirm", IBCConnection.PORT, channelId);
+        connection.invoke(ibc.account, "onChanOpenConfirm", port, channelId);
+    }
+    public void establishDefaultConnection_fromCounterparty() {
+        establishConnection_fromCounterparty(defaultClientId, defaultConnectionId, defaultChannel, defaultCounterpartyPort, defaultCounterpartyChannel, defaultCounterpartyNid, defaultTimeoutHeight);
     }
 
-    public void establishConnection_fromCounterparty(String channelId, String counterpartyChannel, String nid) {
-        channelOpenTry(channelId, counterpartyChannel);
+    public void establishConnection_fromCounterparty(String clientId, String connectionId, String channelId, String counterpartyPort, String counterpartyChannel, String nid, BigInteger timeoutHeight) {
+        connection.invoke(owner, "configureConnection", connectionId, counterpartyPort, nid, clientId, timeoutHeight);
+        channelOpenTry(connectionId, counterpartyPort, channelId, counterpartyChannel);
         channelOpenConfirm(channelId);
-        connection.invoke(owner, "configureChannel", channelId, nid);
     }
 
-    public void establishConnection(String channelId, String counterpartyChannel, String nid) {
-        channelOpenInit(channelId);
+    public void establishDefaultConnection() {
+        establishConnection(defaultClientId, defaultConnectionId, defaultChannel, defaultCounterpartyPort, defaultCounterpartyChannel, defaultCounterpartyNid, defaultTimeoutHeight);
+    }
+
+    public void establishConnection(String clientId, String connectionId, String channelId, String counterpartyPort, String counterpartyChannel, String nid, BigInteger timeoutHeight) {
+        connection.invoke(owner, "configureConnection", connectionId, counterpartyPort, nid, clientId, timeoutHeight);
+        channelOpenInit(connectionId, counterpartyPort, channelId);
         channelOpenAck(channelId, counterpartyChannel);
-        connection.invoke(owner, "configureChannel", channelId, nid);
     }
 }

--- a/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CSMessageRequest.java
+++ b/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CSMessageRequest.java
@@ -102,6 +102,10 @@ public class CSMessageRequest {
     }
 
     private static String[] readProtocols(ObjectReader r) {
+        if( !r.hasNext() ) {
+            return new String[]{};
+        }
+
         r.beginList();
         List<String> protocolsList = new ArrayList<>();
         while(r.hasNext()) {

--- a/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CSMessageRequest.java
+++ b/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CSMessageRequest.java
@@ -28,18 +28,22 @@ import java.util.List;
 public class CSMessageRequest {
     private final String from;
     private final String to;
-    private final String[] protocols;
     private final BigInteger sn;
     private final boolean rollback;
     private final byte[] data;
+    private final String[] protocols;
 
-    public CSMessageRequest(String from, String to, String[] protocols, BigInteger sn, boolean rollback, byte[] data) {
+
+    public CSMessageRequest(String from, String to, BigInteger sn, boolean rollback, byte[] data, String[] protocols) {
         this.from = from;
         this.to = to;
-        this.protocols = protocols;
         this.sn = sn;
         this.rollback = rollback;
         this.data = data;
+        if (protocols == null) {
+            protocols = new String[]{};
+        }
+        this.protocols = protocols;
     }
 
 
@@ -71,14 +75,15 @@ public class CSMessageRequest {
         w.beginList(6);
         w.write(m.from);
         w.write(m.to);
+
+        w.write(m.sn);
+        w.write(m.rollback);
+        w.writeNullable(m.data);
         w.beginList(m.protocols.length);
         for(String protocol : m.protocols) {
             w.write(protocol);
         }
         w.end();
-        w.write(m.sn);
-        w.write(m.rollback);
-        w.writeNullable(m.data);
         w.end();
     }
 
@@ -87,10 +92,10 @@ public class CSMessageRequest {
         CSMessageRequest m = new CSMessageRequest(
                 r.readString(),
                 r.readString(),
-                readProtocols(r),
                 r.readBigInteger(),
                 r.readBoolean(),
-                r.readNullable(byte[].class)
+                r.readNullable(byte[].class),
+                readProtocols(r)
         );
         r.end();
         return m;

--- a/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CSMessageResponse.java
+++ b/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CSMessageResponse.java
@@ -26,7 +26,7 @@ import java.math.BigInteger;
 public class CSMessageResponse {
     public static final int SUCCESS = 0;
     public static final int FAILURE = -1;
-    public static final int BTP_ERROR = -2;
+    public static final int ERROR = -2;
 
     private final BigInteger sn;
     private final int code;

--- a/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CallRequest.java
+++ b/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CallRequest.java
@@ -33,6 +33,9 @@ public class CallRequest {
     public CallRequest(Address from, String to, String[] protocols, byte[] rollback) {
         this.from = from;
         this.to = to;
+        if (protocols == null) {
+            protocols = new String[]{};
+        }
         this.protocols = protocols;
         this.rollback = rollback;
         this.enabled = false;

--- a/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CallService.java
+++ b/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CallService.java
@@ -43,7 +43,11 @@ public interface CallService {
      */
     @Payable
     @External
-    BigInteger sendCallMessage(String _to, String[] sources, String[] destinations, byte[] _data,  @Optional byte[] _rollback);
+    BigInteger sendCallMessage(String _to,
+                                byte[] _data,
+                                @Optional byte[] _rollback,
+                                @Optional String[] sources,
+                                @Optional String[] destinations);
 
     /**
      * Notifies that the requested call message has been sent.

--- a/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CallServiceImpl.java
+++ b/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CallServiceImpl.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class CallServiceImpl implements CallService, FeeManage {
     public static final int MAX_DATA_SIZE = 2048;
     public static final int MAX_ROLLBACK_SIZE = 1024;
-    public static String nid;
+    public static String NID;
 
     private final VarDB<BigInteger> sn = Context.newVarDB("sn", BigInteger.class);
     private final VarDB<BigInteger> reqId = Context.newVarDB("reqId", BigInteger.class);
@@ -45,19 +45,32 @@ public class CallServiceImpl implements CallService, FeeManage {
     private final DictDB<BigInteger, CSMessageRequest> proxyReqs = Context.newDictDB("proxyReqs", CSMessageRequest.class);
     private final BranchDB<byte[], DictDB<String, Boolean>> pendingReqs = Context.newBranchDB("pendingReqs", Boolean.class);
     private final BranchDB<BigInteger, DictDB<String, Boolean>> pendingResponses = Context.newBranchDB("pendingResponses", Boolean.class);
+    private final DictDB<BigInteger, Boolean> successfulResponses = Context.newDictDB("successfulResponses", Boolean.class);
+
+    private final DictDB<String, Address> defaultConnection = Context.newDictDB("defaultConnection", Address.class);
 
     // for fee-related operations
     private final VarDB<Address> admin = Context.newVarDB("admin", Address.class);
     private final VarDB<BigInteger> protocolFee = Context.newVarDB("protocolFee", BigInteger.class);
+    private final VarDB<Address> feeHandler = Context.newVarDB("feeHandler", Address.class);
 
     public CallServiceImpl(String networkId) {
-        nid = networkId;
+        NID = networkId;
+        if (admin.get() == null) {
+            admin.set(Context.getCaller());
+            feeHandler.set(Context.getCaller());
+        }
     }
 
     /* Implementation-specific external */
     @External(readonly=true)
     public String getNetworkAddress() {
-        return new NetworkAddress(nid, Context.getAddress()).toString();
+        return new NetworkAddress(NID, Context.getAddress()).toString();
+    }
+
+    @External(readonly=true)
+    public String getNetworkId() {
+        return NID;
     }
 
     private void checkCallerOrThrow(Address caller, String errMsg) {
@@ -89,7 +102,11 @@ public class CallServiceImpl implements CallService, FeeManage {
     @Override
     @Payable
     @External
-    public BigInteger sendCallMessage(String _to, String[] sources, String[] destinations, byte[] _data,  @Optional byte[] _rollback) {
+    public BigInteger sendCallMessage(String _to,
+                                      byte[] _data,
+                                      @Optional byte[] _rollback,
+                                      @Optional String[] sources,
+                                      @Optional String[] destinations) {
         Address caller = Context.getCaller();
         // check if caller is a contract or rollback data is null in case of EOA
         Context.require(_rollback == null || caller.isContract(), "RollbackNotPossible");
@@ -97,39 +114,40 @@ public class CallServiceImpl implements CallService, FeeManage {
         Context.require(_data.length <= MAX_DATA_SIZE, "MaxDataSizeExceeded");
         Context.require(_rollback == null || _rollback.length <= MAX_ROLLBACK_SIZE, "MaxRollbackSizeExceeded");
 
-        boolean needResponse = _rollback != null;
+        boolean needResponse = _rollback != null && _rollback.length > 0;
         NetworkAddress dst = NetworkAddress.valueOf(_to);
-        BigInteger value = Context.getValue();
-
-        BigInteger requiredFee = BigInteger.ZERO;
-        Map<Address, BigInteger> fees = new HashMap<>();
-        int nrConnections = sources.length;
-        Context.require(nrConnections == destinations.length);
-        for (int i = 0; i < nrConnections; i++) {
-            Address src = Address.fromString(sources[i]);
-            BigInteger fee = getFee(src, dst.net(), needResponse);
-            requiredFee = requiredFee.add(fee);
-            fees.put(src, fee);
-        }
-
-        BigInteger protocolFee = getProtocolFee();
-        requiredFee = requiredFee.add(protocolFee);
-        Context.require(value.compareTo(requiredFee) >= 0, "InsufficientFee");
 
         BigInteger sn = getNextSn();
         if (needResponse) {
-            CallRequest req = new CallRequest(caller, dst.toString(), sources, _rollback);
+            CallRequest req = new CallRequest(caller, dst.net(), sources, _rollback);
             requests.set(sn, req);
         }
-        String from = new NetworkAddress(nid, caller.toString()).toString();
-        CSMessageRequest msgReq = new CSMessageRequest(from, dst.account(), destinations,  sn, needResponse, _data);
+
+        String from = new NetworkAddress(NID, caller.toString()).toString();
+        CSMessageRequest msgReq = new CSMessageRequest(from, dst.account(),  sn, needResponse, _data, destinations);
         byte[] msgBytes = msgReq.toBytes();
-        for (String _src : sources) {
-            Address src = Address.fromString(_src);
-                sendBTPMessage(src, fees.get(src), dst.net(), CSMessage.REQUEST,
+        if (sources == null || sources.length == 0) {
+            Address src = defaultConnection.get(dst.net());
+            BigInteger fee = Context.call(BigInteger.class, src, "getFee", dst.net(), needResponse);
+            sendMessage(src, fee, dst.net(), CSMessage.REQUEST,
                 needResponse ? sn : BigInteger.ZERO, msgBytes);
+        } else {
+            for (String _src : sources) {
+                Address src = Address.fromString(_src);
+                BigInteger fee = Context.call(BigInteger.class, src, "getFee", dst.net(), needResponse);
+                sendMessage(src, fee, dst.net(), CSMessage.REQUEST,
+                    needResponse ? sn : BigInteger.ZERO, msgBytes);
+            }
+
         }
+
+        BigInteger protocolFee = getProtocolFee();
+        BigInteger balance = Context.getBalance(Context.getAddress());
+        Context.require(balance.compareTo(protocolFee) >= 0);
+        Context.transfer(feeHandler.get(), balance);
+
         CallMessageSent(caller, dst.toString(), sn);
+
         return sn;
     }
 
@@ -144,8 +162,13 @@ public class CallServiceImpl implements CallService, FeeManage {
         NetworkAddress from = NetworkAddress.valueOf(req.getFrom());
         CSMessageResponse msgRes = null;
         try {
-            CallServiceReceiver proxy = new CallServiceReceiverScoreInterface(Address.fromString(req.getTo()));
-            proxy.handleCallMessage(req.getFrom(), req.getData(), req.getProtocols());
+            Address to = Address.fromString(req.getTo());
+            if (req.getProtocols().length == 0) {
+                Context.call(to, "handleCallMessage", req.getFrom(), req.getData());
+            } else {
+                Context.call(to, "handleCallMessage", req.getFrom(), req.getData(), req.getProtocols());
+            }
+
             msgRes = new CSMessageResponse(req.getSn(), CSMessageResponse.SUCCESS, "");
         } catch (UserRevertedException e) {
             int code = e.getCode();
@@ -159,11 +182,16 @@ public class CallServiceImpl implements CallService, FeeManage {
             }
             CallExecuted(_reqId, msgRes.getCode(), msgRes.getMsg());
             // send response only when there was a rollback
-            if (req.needRollback()) {
-                BigInteger sn = req.getSn().negate();
-                for (String protocol : req.getProtocols()) {
-                    sendBTPMessage(Address.fromString(protocol), BigInteger.ZERO, from.net(), CSMessage.RESPONSE, sn, msgRes.toBytes());
+            if (!req.needRollback()) {
+                return;
+            }
 
+            BigInteger sn = req.getSn().negate();
+            if (req.getProtocols().length == 0) {
+                sendMessage(defaultConnection.get(from.net()), BigInteger.ZERO, from.net(), CSMessage.RESPONSE, sn, msgRes.toBytes());
+            } else {
+                for (String protocol : req.getProtocols()) {
+                    sendMessage(Address.fromString(protocol), BigInteger.ZERO, from.net(), CSMessage.RESPONSE, sn, msgRes.toBytes());
                 }
             }
         }
@@ -179,8 +207,11 @@ public class CallServiceImpl implements CallService, FeeManage {
 
         CSMessageResponse msgRes = null;
         try {
-            CallServiceReceiver proxy = new CallServiceReceiverScoreInterface(req.getFrom());
-            proxy.handleCallMessage(getNetworkAddress(), req.getRollback(), req.getProtocols());
+            if (req.getProtocols().length == 0) {
+                Context.call(req.getFrom(), "handleCallMessage", getNetworkAddress(), req.getRollback());
+            } else {
+                Context.call(req.getFrom(), "handleCallMessage", getNetworkAddress(), req.getRollback(), req.getProtocols());
+            }
             msgRes = new CSMessageResponse(_sn, CSMessageResponse.SUCCESS, "");
         } catch (UserRevertedException e) {
             int code = e.getCode();
@@ -192,8 +223,14 @@ public class CallServiceImpl implements CallService, FeeManage {
             if (msgRes == null) {
                 msgRes = new CSMessageResponse(_sn, CSMessageResponse.FAILURE, "UnknownFailure");
             }
+
             RollbackExecuted(_sn, msgRes.getCode(), msgRes.getMsg());
         }
+    }
+
+    @External(readonly=true)
+    public boolean verifySuccess(BigInteger sn) {
+        return successfulResponses.getOrDefault(sn, false);
     }
 
     @Override
@@ -223,13 +260,25 @@ public class CallServiceImpl implements CallService, FeeManage {
     /* ========== Interfaces with BMC ========== */
     @External
     public void handleBTPMessage(String _from, String _svc, BigInteger _sn, byte[] _msg) {
+      handleMessage(_from, _sn, _msg);
+    }
+
+    @External
+    public void handleBTPError(String _src, String _svc, BigInteger _sn, long _code, String _msg) {
+        handleError(_sn, _code, _msg);
+    }
+    /* ========================================= */
+
+
+    @External
+    public void handleMessage(String _from, BigInteger _sn, byte[] _msg) {
         CSMessage msg = CSMessage.fromBytes(_msg);
         switch (msg.getType()) {
             case CSMessage.REQUEST:
                 handleRequest(_from, _sn, msg.getData());
                 break;
             case CSMessage.RESPONSE:
-                handleResponse(_from, _sn, msg.getData());
+                handleResponse( _sn, msg.getData());
                 break;
             default:
                 Context.revert("UnknownMsgType(" + msg.getType() + ")");
@@ -237,14 +286,13 @@ public class CallServiceImpl implements CallService, FeeManage {
     }
 
     @External
-    public void handleBTPError(String _src, String _svc, BigInteger _sn, long _code, String _msg) {
-        String errMsg = "BTPError{code=" + _code + ", msg=" + _msg + "}";
-        CSMessageResponse res = new CSMessageResponse(_sn, CSMessageResponse.BTP_ERROR, errMsg);
-        handleResponse(_src, _sn, res.toBytes());
+    public void handleError(BigInteger _sn, long _code, String _msg) {
+        String errMsg = "Error{code=" + _code + ", msg=" + _msg + "}";
+        CSMessageResponse res = new CSMessageResponse(_sn, CSMessageResponse.ERROR, errMsg);
+        handleResponse(_sn, res.toBytes());
     }
-    /* ========================================= */
 
-    private BigInteger sendBTPMessage(Address _connection, BigInteger value, String netTo, int msgType, BigInteger sn, byte[] data) {
+    private BigInteger sendMessage(Address _connection, BigInteger value, String netTo, int msgType, BigInteger sn, byte[] data) {
         CSMessage msg = new CSMessage(msgType, data);
         ConnectionScoreInterface connection = new ConnectionScoreInterface(_connection);
         return connection.sendMessage(value, netTo, NAME, sn, msg.toBytes());
@@ -255,7 +303,8 @@ public class CallServiceImpl implements CallService, FeeManage {
         String[] protocols = msgReq.getProtocols();
         String from = msgReq.getFrom();
         Context.require(NetworkAddress.valueOf(from).net().equals(netFrom));
-        String source = Context.getCaller().toString();
+        Address sourceAddress = Context.getCaller();
+        String source = sourceAddress.toString();
 
         if (protocols.length > 1) {
             byte[] hash = Context.hash("sha-256", data);
@@ -270,9 +319,12 @@ public class CallServiceImpl implements CallService, FeeManage {
             for (String protocol : protocols) {
                 pendingRequests.set(protocol, null);
             }
-        } else {
+        } else if (protocols.length == 1) {
             Context.require(source.equals(protocols[0]));
+        } else {
+            Context.require(sourceAddress.equals(defaultConnection.get(netFrom)));
         }
+
         String to = msgReq.getTo();
         BigInteger reqId = getNextReqId();
         proxyReqs.set(reqId, msgReq);
@@ -281,11 +333,12 @@ public class CallServiceImpl implements CallService, FeeManage {
         CallMessage(msgReq.getFrom(), to, msgReq.getSn(), reqId);
     }
 
-    private void handleResponse(String netFrom, BigInteger sn, byte[] data) {
+    private void handleResponse(BigInteger sn, byte[] data) {
         CSMessageResponse msgRes = CSMessageResponse.fromBytes(data);
         BigInteger resSn = msgRes.getSn();
         CallRequest req = requests.get(resSn);
-        String source = Context.getCaller().toString();
+        Address sourceAddress = Context.getCaller();
+        String source = sourceAddress.toString();
 
         if (req == null) {
             Context.println("handleResponse: no request for " + resSn);
@@ -305,8 +358,10 @@ public class CallServiceImpl implements CallService, FeeManage {
             for (String protocol : protocols) {
                 pendingResponse.set(protocol, null);
             }
-        } else {
+        } else if (protocols.length == 1) {
             Context.require(source.equals(protocols[0]));
+        } else {
+            Context.require(sourceAddress.equals(defaultConnection.get(req.getTo())));
         }
 
         String errMsg = msgRes.getMsg();
@@ -314,9 +369,10 @@ public class CallServiceImpl implements CallService, FeeManage {
         switch (msgRes.getCode()) {
             case CSMessageResponse.SUCCESS:
                 cleanupCallRequest(resSn);
+                successfulResponses.set(resSn, true);
                 break;
             case CSMessageResponse.FAILURE:
-            case CSMessageResponse.BTP_ERROR:
+            case CSMessageResponse.ERROR:
             default:
                 // emit rollback event
                 Context.require(req.getRollback() != null, "NoRollbackData");
@@ -344,14 +400,35 @@ public class CallServiceImpl implements CallService, FeeManage {
         protocolFee.set(_value);
     }
 
+    @External
+    public void  setProtocolFeeHandler(Address address){
+        checkCallerOrThrow(admin(), "OnlyAdmin");
+        feeHandler.set(address);
+    }
+
+    @External
+    public void  setDefaultConnection(String nid, Address connection){
+        checkCallerOrThrow(admin(), "OnlyAdmin");
+        defaultConnection.set(nid, connection);
+    }
+
     @External(readonly=true)
     public BigInteger getProtocolFee() {
         return protocolFee.getOrDefault(BigInteger.ZERO);
     }
 
     @External(readonly=true)
-    public BigInteger getFee(Address _connection, String _net, boolean _rollback) {
-        ConnectionScoreInterface connection = new ConnectionScoreInterface(_connection);
-        return connection.getFee(_net, _rollback);
+    public BigInteger getFee(String _net, boolean _rollback, @Optional String[] sources) {
+        BigInteger fee = getProtocolFee();
+        if (sources == null || sources.length == 0) {
+            return fee.add(Context.call(BigInteger.class, defaultConnection.get(_net), "getFee", _net, _rollback));
+        }
+
+        for (String protocol : sources) {
+            Address address = Address.fromString(protocol);
+            fee = fee.add(Context.call(BigInteger.class, address, "getFee", _net, _rollback));
+        }
+
+        return fee;
     }
 }

--- a/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CallServiceImpl.java
+++ b/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/CallServiceImpl.java
@@ -111,7 +111,6 @@ public class CallServiceImpl implements CallService, FeeManage {
         // check if caller is a contract or rollback data is null in case of EOA
         Context.require(_rollback == null || caller.isContract(), "RollbackNotPossible");
         // check size of payloads to avoid abusing
-        Context.require(_data.length <= MAX_DATA_SIZE, "MaxDataSizeExceeded");
         Context.require(_rollback == null || _rollback.length <= MAX_ROLLBACK_SIZE, "MaxRollbackSizeExceeded");
 
         boolean needResponse = _rollback != null && _rollback.length > 0;
@@ -125,7 +124,10 @@ public class CallServiceImpl implements CallService, FeeManage {
 
         String from = new NetworkAddress(NID, caller.toString()).toString();
         CSMessageRequest msgReq = new CSMessageRequest(from, dst.account(),  sn, needResponse, _data, destinations);
+
         byte[] msgBytes = msgReq.toBytes();
+        Context.require(msgBytes.length <= MAX_DATA_SIZE, "MaxDataSizeExceeded");
+
         if (sources == null || sources.length == 0) {
             Address src = defaultConnection.get(dst.net());
             BigInteger fee = Context.call(BigInteger.class, src, "getFee", dst.net(), needResponse);

--- a/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/DefaultCallServiceReceiver.java
+++ b/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/DefaultCallServiceReceiver.java
@@ -18,10 +18,9 @@ package foundation.icon.btp.xcall;
 
 import foundation.icon.score.client.ScoreInterface;
 import score.annotation.External;
-import score.annotation.Optional;
 
 @ScoreInterface
-public interface CallServiceReceiver {
+public interface DefaultCallServiceReceiver {
 
     /**
      * Handles the call message received from the source chain.
@@ -31,5 +30,5 @@ public interface CallServiceReceiver {
      * @param _data The calldata delivered from the caller
      */
     @External
-    void handleCallMessage(String _from, byte[] _data, @Optional String[] protocols);
+    void handleCallMessage(String _from, byte[] _data);
 }

--- a/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/FeeManage.java
+++ b/contracts/javascore/xcall-multi-protocol/src/main/java/foundation/icon/btp/xcall/FeeManage.java
@@ -52,5 +52,5 @@ public interface FeeManage {
      * @return the sum of the protocol fee and the relay fee
      */
     @External(readonly=true)
-    BigInteger getFee(Address connection, String _net, boolean _rollback);
+    BigInteger getFee(String _net, boolean _rollback, @Optional String[] _sourceProtocols);
 }

--- a/docs/adr/XCall_IBC_Connection.md
+++ b/docs/adr/XCall_IBC_Connection.md
@@ -77,7 +77,7 @@ The Message struct is used for all packets sent. While acknowledgments only cons
 The Message struct is defined as follows:
 ```java
 class Message() {
-    BigIntger sn;
+    BigIntger sn; // Nullable
     BigIntger fee;
     byte[] data;
 
@@ -173,7 +173,6 @@ void sendMessage(String _to, String _svc, BigInteger _sn, byte[] _msg) {
 ```java
 public byte[] onRecvPacket(byte[] calldata, Address relayer) {
     onlyIBCHandler();
-    // TOOD fee logic
 
     Packet packet = Packet.decode(calldata);
     Message msg = Message.fromBytes(packet.getData());
@@ -181,11 +180,13 @@ public byte[] onRecvPacket(byte[] calldata, Address relayer) {
     assert nid != null;
     unclaimedPacketFees[nid][relayer] += msg.getFee();
 
+    if (msg.getSn() == null) {
+        Context.transfer(msg.getFee(), Address.fromBytes(msg.getData()))
+        return  new byte[0]
+    }
+
     if (msg.getSn() > 0) {
         incomingPackets[packet.getDestinationChannel()][msg.getSn()] = packet.getSequence());
-    } else if (msg.getSn() == -1) {
-         Context.transfer(msg.getFee(), Address.fromBytes(msg.getData()))
-         return  new byte[0]
     }
 
     xCall.handleMessage(nid, msg.getSn(), msg.getData());
@@ -274,7 +275,7 @@ public void claimFees(String nid, byte[] address) {
     unclaimedPacketFees[nid][relayer] = null
     assert amount > 0;
     String channel = channels.get(nid);
-    Message msg = new Message(-1, amount, address);
+    Message msg = new Message(null, amount, address);
     Packet packet = Packet(
         port
         channel

--- a/docs/adr/XCall_IBC_Connection.md
+++ b/docs/adr/XCall_IBC_Connection.md
@@ -13,9 +13,9 @@ The sendMessage function is responsible for sending a message to a specified tar
 
 The behavior of sendMessage depends on the value of sn (sequence number). If sn is greater than 0, it indicates a new message that requires a response. In this case, both the sending fee and the response fee should be included. If sn is 0, it signifies a one-way message where no response is expected. If sn is less than 0, it implies that the message is a response to a previously received message. In this scenario, no fee is included in the sending message since it should have already been paid when the positive sn was sent.
 
-After handling the sn value, the sendMessage function triggers the handleBTPMessage function on the targetNetwork. It passes targetNetwork, svc, sn, and msg as arguments to handleBTPMessage. The purpose of this function is to handle the incoming message on the specified targetNetwork's xCall contract.
+After handling the sn value, the sendMessage function triggers the handleMessage function on the targetNetwork. It passes targetNetwork, sn, and msg as arguments to handleMessage. The purpose of this function is to handle the incoming message on the specified targetNetwork's xCall contract.
 
-In case the message fails to be delivered for any reason, the code triggers the handleBTPError function. It passes an empty string as the first argument, svc, sn, errorCode, and errorMessage to the handleBTPError function. The responsibility of this function is to handle errors that occur during the message delivery process.
+In case the message fails to be delivered for any reason, the code triggers the handleError function. It passes sn, errorCode, and errorMessage to the function. The responsibility of this function is to handle errors that occur during the message delivery process.
 
 The second external function, getFee(network, response), calculates and returns the fee required to send a message to the specified network and back. It takes into account the optional response parameter when determining the fee.
 
@@ -24,22 +24,23 @@ In summary, this code snippet illustrates a specific behavior expected from a co
 external function sendMessage(targetNetwork, svc, sn, msg)
     if sn < 0:
         sn = sn.negate()
-    On targetNetwork, trigger handleBTPMessage(targetNetwork, svc, sn, msg)
+    On targetNetwork, trigger handleMessage(targetNetwork, sn, msg)
     if message fails to deliver:
-        trigger handleBTPError("", svc, sn, errorCode, errorMessage)
+        trigger handleBTPError(sn, errorCode, errorMessage)
 ```
 
 ``` javascript
 external function getFee(network, response)
     Returns the fee required to send a message to "network" and back, considering the optional response parameter.
+...
 ```
 
 ## General IBC Connection Design Overview
 The IBC (Inter-Blockchain Communication) connection facilitates communication between different chains using IBC channels and ports. This connection relies on the administrator to associate network IDs with specific connections/ports. Once established, these properties become immutable and cannot be changed. Consequently, users can depend on the stability and reliability of a configured connection to another chain.
 
-For message transmission, the sendPacket function is utilized. All responses are handled through acknowledgments, ensuring reliable delivery. If a packet timeout occurs, it will be treated as an error, indicating a failure in the message transmission process.
+All responses are handled through acknowledgments If a packet timeout occurs, it will be treated as an error.
 
-Two types of fees are associated with this connection. The first fee pertains to delivering the packet itself, while the second fee is related to delivering an acknowledgment. These fee amounts are determined and controlled by the administrator. To ensure user safety, there are caps on the fee amounts, preventing excessive charges.
+Two types of fees are associated with this connection. The first fee pertains to delivering the packet itself, while the second fee is related to delivering an acknowledgment. These fee amounts are determined and controlled by the administrator. To ensure user safety, there should be caps on the fee amounts, preventing excessive charges.
 
 Additionally, the packet fee rewards are included with the message and stored on the counterparty connections. These rewards can be claimed separately through a distinct message, providing a mechanism for managing and distributing the associated fees.
 
@@ -47,8 +48,12 @@ Additionally, the packet fee rewards are included with the message and stored on
 
 ### Storage
 ```
-TIMEOUT_HEIGHT = <Some high fixed value>
 configuredNetworkIds : connection->port->NetworkId
+configuredClients : connection->clientId
+configuredTimeoutHeight : connection->timeoutHeight
+
+lightClients : channelId->clientId
+timeoutHeights : channelId->timeoutHeight
 
 PORT: portId
 channels : NetworkId -> channelId
@@ -72,7 +77,7 @@ The Message struct is used for all packets sent. While acknowledgments only cons
 The Message struct is defined as follows:
 ```java
 class Message() {
-    String sn;
+    BigIntger sn;
     BigIntger fee;
     byte[] data;
 
@@ -90,6 +95,16 @@ data: The data attribute stores the xCall messsage or int case of a fee claim it
 
 The toBytes() method is implemented to convert the Message struct into a byte array representation using the RLP (Recursive Length Prefix) encoding.
 
+### Contract initialization
+```javascript
+function init(Address _xCall, Address _ibc, String port) {
+    xCall.set(_xCall);
+    ibc.set(_ibc);
+    admin.set(Context.getCaller());
+    PORT = port
+}
+```
+
 ### Sending Messages
 ```java
 /**
@@ -103,19 +118,22 @@ The toBytes() method is implemented to convert the Message struct into a byte ar
  */
 void sendMessage(String _to, String _svc, BigInteger _sn, byte[] _msg) {
     onlyXCall();
+    String channel = channels.get(caller).get(_to);
+
     if (_sn.compareTo(BigInteger.ZERO) < 0) {
         writeAcknowledgement(_to, _sn.negate(), _msg);
         return
     }
+
+    seqNum = ibc.getNextSequenceSend(PORT, channel)
     packetfee = sendPacketFee.get(_to)
     _ackFee = 0;
     if (sn.compareTo(BigInteger.ZERO) > 0) {
         _ackFee = ackFee[_to]
+        unclaimedAckFees[_to][seqNum] = _ackFee;
     }
 
     assert Context.value() == packetfee + _ackFee
-
-    String channel = channels.get(_to);
     if (!_sn.equals(BigInteger.ZERO)) {
         outgoingPackets[channel][seqNum] = _sn;
     }
@@ -127,10 +145,10 @@ void sendMessage(String _to, String _svc, BigInteger _sn, byte[] _msg) {
         destinationPort[channel]
         destinationChannel[channel]
         msg.toBytes()
-        TIMEOUT_HEIGHT
+        getTimeoutHeight(channel)
     );
 
-    unclaimedAckFees[_to][packet.sequence] = _ackFee;
+
 
     ibc.sendPacket(packet);
 }
@@ -155,6 +173,8 @@ void sendMessage(String _to, String _svc, BigInteger _sn, byte[] _msg) {
 ```java
 public byte[] onRecvPacket(byte[] calldata, Address relayer) {
     onlyIBCHandler();
+    // TOOD fee logic
+
     Packet packet = Packet.decode(calldata);
     Message msg = Message.fromBytes(packet.getData());
     String nid = networkIds.get(packet.getDestinationChannel());
@@ -162,13 +182,13 @@ public byte[] onRecvPacket(byte[] calldata, Address relayer) {
     unclaimedPacketFees[nid][relayer] += msg.getFee();
 
     if (msg.getSn() > 0) {
-        incomingPackets[packet.getDestinationChannel()][msg.getSn()] = packet.getSequence();
+        incomingPackets[packet.getDestinationChannel()][msg.getSn()] = packet.getSequence());
     } else if (msg.getSn() == -1) {
          Context.transfer(msg.getFee(), Address.fromBytes(msg.getData()))
          return  new byte[0]
     }
 
-    xCall.handleBTPMessage(nid, "xcall", msg.getSn(), msg.getData());
+    xCall.handleMessage(nid, msg.getSn(), msg.getData());
     return new byte[0];
 }
 ```
@@ -187,7 +207,7 @@ public void onAcknowledgementPacket(byte[] calldata, byte[] acknowledgement, Add
     Context.transfer(unclaimedAckFees[_to][packet.sequence], relayer)
     unclaimedAckFees[nid][packet.sequence] = null
 
-    xCall.handleBTPMessage(nid, "xcall", sn, acknowledgement);
+    xCall.handleMessage(nid, sn, acknowledgement);
 }
 ```
 
@@ -200,14 +220,23 @@ public void onTimeoutPacket(byte[] calldata, Address relayer) {
     outgoingPackets.at(packet.getSourceChannel()).set(packet.getSequence(), null);
     String nid = networkIds[packet.getSourceChannel()];
 
+    assert sn != null;
+
     fee = msg.getFee();
     if (sn != null) {
         fee += unclaimedAckFees[nid][packet.sequence];
         unclaimedAckFees[nid][packet.sequence] = null
-        xCall.handleBTPError("", "xcall", sn, -1, "Timeout");
+        xCall.handleError(sn, -1, "Timeout");
     }
 
     Context.transfer(fee, relayer)
+}
+```
+
+```java
+private Height getTimeoutHeight(String channelId) {
+    height = ibc.getLatestHeight(lightClients[channelId])
+    return height + timeoutHeights[channelId]
 }
 ```
 
@@ -219,22 +248,30 @@ public void onTimeoutPacket(byte[] calldata, Address relayer) {
  * If _to is not reachable, then it reverts.
  * If _to does not exist in the fee table, then it returns zero.
  *
- * @param _to       String ( BTP Network Address of the destination BMC )
+ * @param _to       String Network Id of target chain
  * @param _response Boolean ( Whether the responding fee is included )
  * @return Integer (The fee of sending a message to a given destination network )
  */
 public BigInteger getFee(String _to, boolean _response) {
-    fee = 0
+    fee = sendPacketFee[_to]
     if response {
-        fee = ackFee[_to]
+        fee += ackFee[_to]
     }
 
-    return sendPacketFee[_to] + fee
+    return fee
 }
-
+```
+```java
+/**
+ * Claims fees gathered on 'nid' chain to specific address native to that chain.
+ *
+ * @param nid       String Network Id of target chain
+ * @param address Byte representation of address on target chain
+ */
 public void claimFees(String nid, byte[] address) {
-    relayer = getCaller()
+    relayer = Context.getCaller()
     BigInteger amount = unclaimedPacketFees[nid][relayer]
+    unclaimedPacketFees[nid][relayer] = null
     assert amount > 0;
     String channel = channels.get(nid);
     Message msg = new Message(-1, amount, address);
@@ -244,10 +281,14 @@ public void claimFees(String nid, byte[] address) {
         destinationPort[channel]
         destinationChannel[channel]
         msg
-        TIMEOUT_HEIGHT
+        getTimeoutHeight(channel)
     );
     ibc.sendPacket(packet);
 
+}
+
+public BigInteger getUnclaimedFees(String nid, Address relayer) {
+    return  unclaimedPacketFees[nid][relayer]
 }
 
 ```
@@ -260,15 +301,18 @@ public void onChanOpenInit(int order, String[] connectionHops, String portId, St
     assert order == Undorderd
 
     // TODO verify version
-    Counterparty counterparty = Counterparty.decode(counterpartyPb);
+    String connectionId = connectionHops[0]
+    Counterparty counterparty = Counterparty.decode(counterpartyPb)
     String counterpartyPortId = counterparty.getPortId()
-    String counterPartyNid = configuredNetworkIds[connectionHops[0]][counterpartyPortId]
+    String counterPartyNid = configuredNetworkIds[connectionId][counterpartyPortId]
     assert portId == PORT;
-    assert counterPartNid != null
+    assert counterPartyNid != null
     assert channels[counterPartyNid] == null
+    lightClients[channelId] = configuredClients[connectionId]
     destinationPort[channelId] = counterpartyPortId
     channels[counterPartyNid] = channelId
     networkIds[channelId] = counterPartyNid
+    timeoutHeights[channelId] = configuredTimeoutHeight[connectionId]
 }
 ```
 
@@ -280,17 +324,19 @@ public void onChanOpenTry(int order, String[] connectionHops, String portId, Str
     assert order == Undorderd
     // TODO verify version
 
-    Counterparty counterparty = Counterparty.decode(counterpartyPb);
+    String connectionId = connectionHops[0]
+    Counterparty counterparty = Counterparty.decode(counterpartyPb)
     String counterpartyPortId = counterparty.getPortId()
-    String counterPartyNid = configuredNetworkIds[connectionHops[0]][counterpartyPortId]
+    String counterPartyNid = configuredNetworkIds[connectionId][counterpartyPortId]
     assert portId == PORT;
-    assert counterPartNid != null
+    assert counterPartyNid != null
     assert channels[counterPartyNid] == null
-
+    lightClients[channelId] = configuredClients[connectionId]
     destinationPort[channelId] = counterpartyPortId
-    channels[counterPartyNid] = channelId
     destinationChannel[channelId] = counterparty.getChannelId();
+    channels[counterPartyNid] = channelId
     networkIds[channelId] = counterPartyNid
+    timeoutHeights[channelId] = configuredTimeoutHeight[connectionId]
 }
 ```
 ```java
@@ -310,15 +356,10 @@ public void onChanOpenConfirm(String portId, String channelId) {
 }
 ```
 
-Once a channel is closed, no further action is required. By assigning an empty string to the channel ID, the IBC system ensures that no messages will be processed through that specific channel. This effectively halts any communication through the closed channel. However, timeouts are still implemented to allow for the recovery of lost messages.
-
-Setting the channel ID to an empty string also serves another important purpose: it prevents the administrator from replacing the connection. With an empty channel ID, any attempt to modify or replace the existing connection is prohibited. Instead, to establish a new connection with the desired chain, a new contract must be deployed. This ensures the stability and integrity of the established connection,
-
 *Todo improve recovery without redeploying*
 ```java
 public void onChanCloseInit(String portId, String channelId) {
-    nid = networkIds[channelId]
-    channels[nid] = ""
+    revert()
 }
 ```
 ```java
@@ -337,20 +378,32 @@ public void transferAdmin(Address admin) {
 ```
 
 ```java
-public void configureConnection(String connectionId, String portId, String counterpartyNid) {
+/**
+ * Configures a ibc connection so that a channel can be establised for a specigic nid
+
+
+ * @param connectionId The connection id of the connection/chain to open the connection to
+ * @param portId  The allocated port name of the connection on the counterparty chain
+ * @param counterpartyNid The network Id to be associated with this connection
+ * @param clientId The lightClient associated with this connection
+ * @param timeoutHeight The timeoutheight to be used on packets, it is recommended to use a high value similar to the trusting period of the lightclient.
+ */
+public void configureConnection(String connectionId, String portId, String counterpartyNid, String clientId, BigInteger timeoutHeight) {
     onlyAdmin();
     assert configuredNetworkIds[connectionId][portId] == null
     assert channels[counterpartyNid] == null;
     configuredNetworkIds[connectionId][portId] = counterpartyNid
+    configuredClients[connectionId] = clientId
+    configuredTimeoutHeight[connectionId] = timeoutHeight
 }
 ```
 
 ```java
-void setFee(String _to, BigIntger packetFee, BigIntger ackFee) {
+void setFee(String nid, BigInteger packetFee, BigInteger ackFee) {
     onlyAdmin();
     //check chainn specfic limits
-    sendPacketFee[_to] = packetFee
-    ackFee[_to] = ackFee
+    sendPacketFee[nid] = packetFee
+    ackFee[nid] = ackFee
 }
 ```
 
@@ -363,7 +416,9 @@ After a connections is established for a specific networkId it can't change but 
 
 ## Implementations
 
+
 ## History
+
 
 ## Copyright
 

--- a/docs/adr/XCall_IBC_Connection.md
+++ b/docs/adr/XCall_IBC_Connection.md
@@ -178,8 +178,6 @@ public byte[] onRecvPacket(byte[] calldata, Address relayer) {
     Message msg = Message.fromBytes(packet.getData());
     String nid = networkIds.get(packet.getDestinationChannel());
     assert nid != null;
-    unclaimedPacketFees[nid][relayer] += msg.getFee();
-
     if (msg.getSn() == null) {
         Context.transfer(msg.getFee(), Address.fromBytes(msg.getData()))
         return  new byte[0]
@@ -189,6 +187,7 @@ public byte[] onRecvPacket(byte[] calldata, Address relayer) {
         incomingPackets[packet.getDestinationChannel()][msg.getSn()] = packet.getSequence());
     }
 
+    unclaimedPacketFees[nid][relayer] += msg.getFee();
     xCall.handleMessage(nid, msg.getSn(), msg.getData());
     return new byte[0];
 }
@@ -384,16 +383,16 @@ public void transferAdmin(Address admin) {
 
 
  * @param connectionId The connection id of the connection/chain to open the connection to
- * @param portId  The allocated port name of the connection on the counterparty chain
+ * @param counterpartyPortId  The allocated port name of the connection on the counterparty chain
  * @param counterpartyNid The network Id to be associated with this connection
  * @param clientId The lightClient associated with this connection
  * @param timeoutHeight The timeoutheight to be used on packets, it is recommended to use a high value similar to the trusting period of the lightclient.
  */
-public void configureConnection(String connectionId, String portId, String counterpartyNid, String clientId, BigInteger timeoutHeight) {
+public void configureConnection(String connectionId, String counterpartyPortId, String counterpartyNid, String clientId, BigInteger timeoutHeight) {
     onlyAdmin();
-    assert configuredNetworkIds[connectionId][portId] == null
+    assert configuredNetworkIds[connectionId][counterpartyPortId] == null
     assert channels[counterpartyNid] == null;
-    configuredNetworkIds[connectionId][portId] = counterpartyNid
+    configuredNetworkIds[connectionId][counterpartyPortId] = counterpartyNid
     configuredClients[connectionId] = clientId
     configuredTimeoutHeight[connectionId] = timeoutHeight
 }

--- a/docs/adr/multi-protocol-xcall.md
+++ b/docs/adr/multi-protocol-xcall.md
@@ -10,15 +10,15 @@ xCall is a standard interface to make calls between different blockchain network
 
 ## Prerequisites
 ### Network Addresses
-XCall uses network address to refer to different addresses across many networks. A "network address" consists of a network and an account section. A network address is represented as a string with "networkId" and "account" seperated by /.
+XCall uses network address to refer to different addresses across many networks. A "network address" consists of a network and an account section. A network address is represented as a string with "networkId" and "account" separated by /.
 A networkId is a unique id of a network and there can't be two networks with the same id connection to the same xCall network.
 
 ### Connections
-XCall is designed to utilize a wide range of bridging protocols that facilitate data transfer, known as connections. These connections can be selected by users and dApps, ensuring a permissionless protocol. However, this places a responsibility on the dApps to verify that they exclusively accept messages from trusted protocols.
+XCall is designed to utilize a wide range of bridging protocols that facilitate data transfer, known as connections. These connections can be selected by users and dApps, ensuring a permissionless protocol. However, this places a responsibility on the dApps to verify that they exclusively accept messages from trusted protocols. Users can also opt to use the default connections set up by the xCall admin and in this case does not need to manage connections at all.
 
 ## Protocol Specification
 ### Sending Messages
-Sending messages via xCall is simply done by calling sendCallMessage on the xCall contract. To Address is a networkAddress used by xCall to figure out the destination chain.
+Sending messages via xCall is simply done by calling sendCallMessage on the xCall contract. `_to` address is a networkAddress used by xCall to figure out the destination chain.
 The user can also  specify which connections to use, if not specified the default connections will be used. This also allows dapps to have their messages secured by multiple protocols.
 
 The default connections are specified by and admin and can be changed at any time.
@@ -29,20 +29,20 @@ The default connections are specified by and admin and can be changed at any tim
  * @param _to The network address of the callee on the destination chain
  * @param _data The calldata specific to the target contract
  * @param _rollback (Optional) The data for restoring the caller state when an error occurred
- * @param _sourceProtocols  (Optional) The contracts that will be used to send the message
- * @param _destinationProtocols (Optional) The addresses of the contracts that xcall will expect the message from.
+ * @param sources  (Optional) The contracts that will be used to send the message
+ * @param destinations (Optional) The addresses of the contracts that xcall will expect the message from.
  *
  * @return The serial number of the request
  */
 payable external sendCallMessage(String _to,
                                 byte[] _data,
                                 @Optional bytes _rollback,
-                                @Optional String[] _sourceProtocols
-                                @Optional String[] _destinationProtocols) return Integer;
+                                @Optional String[] sources
+                                @Optional String[] destinations) return Integer;
 ```
 ### Events
 #### CallMessage
-CallMessage event is emitted when a new message is recived by xCall and is ready to be executed.
+CallMessage event is emitted when a new message is received by xCall and is ready to be executed.
 
  `_from` The network address of the caller on the source chain
  `_to` A string representation of the callee address
@@ -70,7 +70,7 @@ CallExecuted{
 }
 ```
 #### ResponseMessage
-ResponseMessage is emited for all two-way messages (i.e., _rollback is non-null), the xcall on the source chain receives a response message from the xcall on the destination chain and emits the following event regardless of its success or not.
+ResponseMessage is emitted for all two-way messages (i.e., _rollback is non-null), the xcall on the source chain receives a response message from the xcall on the destination chain and emits the following event regardless of its success or not.
  `_sn` The message id
  `_code` The execution result code (0: Success, -1: Unknown generic failure, >=1: User defined error code)
  `_msg` The result message
@@ -108,7 +108,7 @@ RollbackExecuted{
 #### CallMessageSent
 CallMessageSent is emitted when for each message sent.
  ` _from` The network address of the caller
- `_to` he network address of the calle
+ `_to` The network address of the calle
  `_sn` The serial number of the request
 
 ```javascript
@@ -146,7 +146,7 @@ external executeRollback(BigInteger _sn);
 
 #### Handling
 
-When the user calls executeCall or executeRollback method, the xcall invokes the following predefined method in the target DApp with the calldata associated in _reqId. If only using default protocols implementing only the two parameter version is prefered
+When the user calls executeCall or executeRollback method, the xcall invokes the following predefined method in the target DApp with the calldata associated in _reqId. If only using default protocols implementing only the two parameter version is preferred
 ```javascript
 /**
  * Handles the call message received from the source chain.
@@ -161,64 +161,67 @@ external handleCallMessage(String _from, byte[] _data, @Optional String[] _proto
 ```
 
 #### Success verification
-If rollback was specified and the call was succesful, that success can be verifed, which means you xCall did succed executing on the target chain.
+If rollback was specified and the call was successful, that success can be verified
 
 
 ```javascript
 /**
- * checks if message '_sn' did succced on target chain.
+ * checks if message '_sn' did succeed on target chain.
  *
  * @param _sn The serial number of the request
  *
- * @return If the '_sn' has recived a successs response
+ * @return If the '_sn' has received a success response
  */
 external readonly verifySuccess(BigInteger _sn) returns boolean;
 ```
 
 ### Fee Managment
-Sending a message through xCall has 2 types of fees. One for using the protocol and one for the connections used.
-To figure out what fee to send dapps there should be two methods to fetch the protocol fee and specific fee for a protocol.
+Sending a message through xCall has 2 types of fees. One for using the protocol and one for each connections used.
+
 ```javascript
 /**
  * Gets the fee for delivering a message to the _net.
  * If the sender is going to provide rollback data, the _rollback param should set as true.
- * The returned fee is the relay fee required by the connection.
+ * The returned fee is the total fee required to send the message.
  *
  * @param _protocol The protocol/connection used
  * @param _net The network id
  * @param _rollback Indicates whether it provides rollback data
- * @return the  relay fee
+ * @param sources The protocols used to send the message is omitted default protocol is used.
+ * @return The total fee of sending the message
  */
-external readonly getFee(String _protocol, String _net, boolean _rollback) Returns Integer;
+external readonly  getFee(String _net,
+                          boolean _rollback
+                          @Optional String[] sources) returns Integer;
 ```
 
 ```javascript
 /**
- * Gets the fee for sending a xCall message
+ * Gets the protocol fee for sending a xCall message
  *
  * @return the xCall protocol fee
  */
-external readonly  getProtocolFee() Returns Integer;
+external readonly getProtocolFee() Returns Integer;
 ```
 
 ### Error Handling
 **TODO: This section is not finished**
-Since oneway messages are standalone not much happends if they are dropped or lost but when using multi protocol with rollbacks there are a few cases where extra handling is needed
+Since one way messages are standalone not much happens if they are dropped or lost but when using multi protocol with rollbacks there are a few cases where extra handling is needed
 
 ##### Partial delivery: Message is dropped by one or more protocol but delivered by others.
-**Mitigation**: If message is a oneway message the recommended approach would be to dissallow messages from the non working protocol and then safley be able to resend message without worrying about double spending.
-If message requires rollback start a timed rollback which will rollback the message after x days via the protocols that delivered the message. Once rollbacked use forced rollback to try a rollback wihtout waiting for all protocols.
+**Mitigation**: If message is a one way message the recommended approach would be to disallow messages from the non working protocol and then safely be able to resend message without worrying about double spending.
+If message requires rollback start a timed rollback which will rollback the message after x days via the protocols that delivered the message. Once rollbacked use forced rollback to try a rollback without waiting for all protocols.
 
 ##### Dropped package: Message is dropped by all connections.
 **Mitigation**: All protocols involved should be removed as trusted in your dapp. Then with new connections it would be safe to resend the message. If the original message required rollback it has to be solved through other means, like governance or similar.
 
-##### Partial failure: Message fails to be deliverd and trigger rollbacks via one or more protocols but delivered by others.
+##### Partial failure: Message fails to be delivered and trigger rollbacks via one or more protocols but delivered by others.
 **Mitigation**: Sames a partial delivery but a forced rollback should not be needed since all protocols will rollback
 
 ##### Partial failure delivery: Message rollback is dropped by one or more protocols but delivered by others.
 **Mitigation**: Once removing the non working protocol you can try force rollback with the protocols that has delivered the rollback.
 
-##### Dropped failure delivery: Rollbnack is dropped by all connections:
+##### Dropped failure delivery: Rollback is dropped by all connections:
 **Mitigation**: All protocols involved should be removed as trusted in your dapp. After that it has to be solved through other means, like governance or similar.
 
 
@@ -235,9 +238,9 @@ The sendMessage function is responsible for sending a message to a specified tar
 
 The behavior of sendMessage depends on the value of sn (sequence number). If sn is greater than 0, it indicates a new message that requires a response. In this case, both the sending fee and the response fee should be included. If sn is 0, it signifies a one-way message where no response is expected. If sn is less than 0, it implies that the message is a response to a previously received message. In this scenario, no fee is included in the sending message since it should have already been paid when the positive sn was sent.
 
-After handling the sn value, the sendMessage function triggers the handleBTPMessage function on the targetNetwork. It passes targetNetwork, svc, sn, and msg as arguments to handleBTPMessage. The purpose of this function is to handle the incoming message on the specified targetNetwork's xCall contract.
+After handling the sn value, the sendMessage function triggers the handleMessage function on the targetNetwork. It passes targetNetwork, sn, and msg as arguments to handleMessage. The purpose of this function is to handle the incoming message on the specified targetNetwork's xCall contract.
 
-In case the message fails to be delivered for any reason, the code triggers the handleBTPError function. It passes an empty string as the first argument, svc, sn, errorCode, and errorMessage to the handleBTPError function. The responsibility of this function is to handle errors that occur during the message delivery process.
+In case the message fails to be delivered for any reason, the code triggers the handleError function. It passes sn, errorCode, and errorMessage to the function. The responsibility of this function is to handle errors that occur during the message delivery process.
 
 The second external function, getFee(network, response), calculates and returns the fee required to send a message to the specified network and back. It takes into account the optional response parameter when determining the fee.
 
@@ -246,9 +249,9 @@ In summary, this code snippet illustrates a specific behavior expected from a co
 external function sendMessage(targetNetwork, svc, sn, msg)
     if sn < 0:
         sn = sn.negate()
-    On targetNetwork, trigger handleBTPMessage(targetNetwork, svc, sn, msg)
+    On targetNetwork, trigger handleMessage(targetNetwork, sn, msg)
     if message fails to deliver:
-        trigger handleBTPError("", svc, sn, errorCode, errorMessage)
+        trigger handleError(sn, errorCode, errorMessage)
 ```
 ``` javascript
 external function getFee(network, response)
@@ -264,19 +267,19 @@ RLP encoding order is the same as the order they are defined in below.
 ##### CSMessageRequest
 ```javascript
 CSMessageRequest {
-    String to;
-    String[] protocols;
     String from;
+    String to;
     BigInteger sn;
     boolean rollback;
     bytes data;
+    String[] protocols;
 }
 ```
 ##### CSMessageResponse
 ```javascript
 int SUCCESS = 0;
 int FAILURE = -1;
-int BTP_ERROR = -2;
+int ERROR = -2;
 CSMessageResponse {
     BigInteger sn;
     int code;
@@ -319,28 +322,41 @@ proxyReqs: reqId -> CSMessageRequest
 # default values should be false in case of boolean storage
 pendingReqs: msgHash -> connection address -> boolean
 pendingResponses: sn -> connection address -> boolean
-succesfulResponses: sn -> boolean
+successfulResponses: sn -> boolean
 
 admin: <admin>
 defaultConnection: networkId -> Address
 protocolFee: <protocolFee>
+feeHandler: <Address>
 ```
+
+### Contract initialization
+```javascript
+function init(String networkId) {
+    NID = networkId
+    if admin == null
+        admin = getCaller();
+        feeHandler = getCaller();
+
+}
+```
+
 ### Communication
 #### Sending messages
-`sendCallMessage` sends a some arbitrary data to `_to` via a path specifed by the caller.
+`sendCallMessage` sends a some arbitrary data to `_to` via a path specified by the caller.
 
 `_to`: The network address of the target contract.
-`_sourceProtocols`: A set of addresses representing the connections to be used when sending the message. These connections are also used to verify potential rollbacks
-`_destinationProtols`: The addresses that the target contract should wait for messages from before considering the it complete.
 `_data`: The data to be sent to the `_to` contract.
 `_rollback`: The data to be returned to the caller in case of failure.
+`sources`: A set of addresses representing the connections to be used when sending the message. These connections are also used to verify potential rollbacks
+`destination`: The addresses that the target contract should wait for messages from before considering the it complete.
 
 ```javascript
 payable external function sendCallMessage(String _to,
                                           byte[] _data,
                                           @Optional bytes _rollback,
-                                          @Optional String[] _sourceProtocols
-                                          @Optional String[] _destinationProtocols) returns Integer {
+                                          @Optional String[] sources
+                                          @Optional String[] destinations) returns Integer {
     caller = getCaller()
     require(caller.isContract() || _rollback == null, "RollbackNotPossible");
     require(_rollback == null || _rollback.length <= MAX_ROLLBACK_SIZE, "MaxRollbackSizeExceeded")
@@ -349,27 +365,30 @@ payable external function sendCallMessage(String _to,
     dst = NetworkAddress(_to)
     from = NetworkAddress(NID, caller).toString()
 
-    needResponse = _rollback != null
+    needResponse = _rollback != null && _rollback.length > 0
     if needResponse:
-        req = CallRequest(caller, dst.net(), _sourceProtocols, _rollback)
+        req = CallRequest(caller, dst.net(), sources, _rollback)
         requests[sn] = req
 
 
-    msgReq = CSMessageRequest(from, dst.account(), _destinationProtocols, sn, needResponse, _data)
+    msgReq = CSMessageRequest(from, dst.account(), sn, needResponse, _data, destinations)
     msg = CSMessage(CSMessage.REQUEST, msgReq.toBytes()).toBytes();
     require(msg.length <= MAX_DATA_SIZE, "MaxDataSizeExceeded")
 
     sendSn = needResponse ? sn : 0
-    if _sourceProtocols == []:
+    if sources == []:
         src = defaultConnection[dst.net()]
         fee = src->getFee(dst.net(), needResponse)
         src->sendMessage(fee, dst.net(), "xcall", sendSn, msg)
     else:
-        for src in _sourceProtocols:
+        for src in sources:
             fee = src->getFee(dst.net(), needResponse)
             src->sendMessage(fee, dst.net(), "xcall", sendSn, msg)
 
-    transferRemaningBalanceToProtocolFeeHandler()
+
+    remaningBalance = getBalance();
+    require(remaningBalance >= getProtocolFee())
+    transfer(feeHandler, balance)
     emit CallMessageSent(caller, dst.toString(), sn)
 
     return sn
@@ -377,10 +396,9 @@ payable external function sendCallMessage(String _to,
 
 ```
 #### Receiving messages
-`handleBTPMessage` is the external function used by connections to deliver messages.
-`_svc` parameter can be ignored and is only relevant if xCall is used with the BTP protocol.
+`handleMessage` is the external function used by connections to deliver messages.
 ```javascript
-external function handleBTPMessage(String _from, _svc String, Integer _sn, bytes _msg) {
+external function handleMessage(String _from, Integer _sn, bytes _msg) {
     msg = CSMessage.decode(_msg);
     switch (msg.type):
         case CSMessage.REQUEST:
@@ -393,14 +411,28 @@ external function handleBTPMessage(String _from, _svc String, Integer _sn, bytes
             Context.revert("UnknownMsgType(" + msg.type + ")");
 }
 ```
-`handleBTPError` is the external function used by connections to report error messages.
-`_svc` parameter can be ignored and is only relevant if xCall is used with the BTP protocol.
-`_src` parameter here can be ignored since the message never reached another chain.
+`handleError` is the external function used by connections to report error messages..
+```javascript
+external function handleError(BigInteger _sn, long _code, String _msg) {
+        String errMsg = "Error{code=" + _code + ", msg=" + _msg + "}";
+        CSMessageResponse res = CSMessageResponse(_sn, CSMessageResponse.ERROR, errMsg);
+        handleResponse(_sn, res.toBytes());
+}
+```
+
+`handleBTPMessage` Can be added to natively support the BTP protocol without a standalone connection.
+
+```javascript
+external function handleBTPMessage(String _from, _svc String, Integer _sn, bytes _msg) {
+    // verify svc is as registered
+    handleMessage(_from, _sn, _msg)
+}
+ ```
+`handleBTPError` Can be added to natively support the BTP protocol without a standalone connection.
 ```javascript
 external function handleBTPError(String _src, String _svc, BigInteger _sn, long _code, String _msg) {
-        String errMsg = "Error{code=" + _code + ", msg=" + _msg + "}";
-        CSMessageResponse res = CSMessageResponse(_sn, CSMessageResponse.BTP_ERROR, errMsg);
-        handleResponse(_sn, res.toBytes());
+    // verify svc is as registered
+    handleError(_sn, _code, _msg)
 }
 ```
 
@@ -459,10 +491,10 @@ internal function handleResponse(sn Integer, data bytes) {
         switch response.getCode():
             case CSMessageResponse.SUCCESS:
                 requests[resSn] = null;
-                succesfulResponses[resSn] = 1;
+                successfulResponses[resSn] = 1;
                 break;
             case CSMessageResponse.FAILURE:
-            case CSMessageResponse.BTP_ERROR:
+            case CSMessageResponse.ERROR:
             default:
                 // emit rollback event
                 require(req.rollback != null, "NoRollbackData");
@@ -535,7 +567,6 @@ adminOnly function setProtocolFeeHandler(Address address){
 }
 
 adminOnly function setProtocolFee(Integer fee){
-    // saftey check amount to be resonable.
     protocolFee  = fee
 }
 
@@ -565,14 +596,25 @@ external readonly function  getProtocolFee() returns Integer {
 ```
 
 ```javascript
-external readonly function  getFee(Address _connection, String _net, boolean _rollback) returns Integer {
-    return _connection->getFee(_net, _rollback);
+external readonly function  getFee(String _net,
+                                   boolean _rollback
+                                   @Optional String[] sources)
+                                        returns Integer {
+    fee = protocolFee;
+    if sources == [] {
+        return defaultConnection[_net]->getFee(_net, _rollback) + fee
+    }
+
+
+    for protocol in sources:
+        fee += protocol->getFee(_net, _rollback)
+    return fee
 }
 ```
 
 ```javascript
 external readonly function  verifySuccess(Integer sn) returns boolean {
-    return succesfulResponses[sn];
+    return successfulResponses[sn];
 }
 ```
 


### PR DESCRIPTION
Add fee logic to connection, allow xCall to be used the same as original xCall by introducing optional parameters and admin controlled default protocols. Use per connection timeout height based on each lightclient.

## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
