### PR TITLE
feat: Remove commitment prefix

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics03/connection/IBCConnection.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics03/connection/IBCConnection.java
@@ -1,5 +1,9 @@
 package ibc.ics03.connection;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+
 import ibc.icon.interfaces.ILightClient;
 import ibc.icon.score.util.ByteUtil;
 import ibc.icon.score.util.Logger;
@@ -12,19 +16,13 @@ import ibc.ics24.host.IBCCommitment;
 import icon.proto.core.client.Height;
 import icon.proto.core.connection.ConnectionEnd;
 import icon.proto.core.connection.Counterparty;
-import icon.proto.core.connection.MerklePrefix;
 import icon.proto.core.connection.Version;
 import score.Context;
 import scorex.util.ArrayList;
 
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.List;
-
 public class IBCConnection extends IBCClient {
     public static final String v1Identifier = "1";
     public static final List<String> supportedV1Features = List.of("ORDER_ORDERED", "ORDER_UNORDERED");
-    public static final byte[] commitmentPrefix = "commitments".getBytes();
 
     Logger logger = new Logger("ibc-core");
 
@@ -64,13 +62,9 @@ public class IBCConnection extends IBCClient {
         connection.setDelayPeriod(msg.getDelayPeriod());
         connection.setCounterparty(counterparty);
 
-        MerklePrefix prefix = new MerklePrefix();
-        prefix.setKeyPrefix(commitmentPrefix);
-
         Counterparty expectedCounterparty = new Counterparty();
         expectedCounterparty.setClientId(msg.getClientId());
         expectedCounterparty.setConnectionId("");
-        expectedCounterparty.setPrefix(prefix);
 
         ConnectionEnd expectedConnection = new ConnectionEnd();
         expectedConnection.setClientId(counterparty.getClientId());
@@ -120,13 +114,9 @@ public class IBCConnection extends IBCClient {
         // require(validateSelfClient(msg.clientStateBytes), "failed to validate self
         // client state");
 
-        MerklePrefix prefix = new MerklePrefix();
-        prefix.setKeyPrefix(commitmentPrefix);
-
         Counterparty expectedCounterparty = new Counterparty();
         expectedCounterparty.setClientId(connection.getClientId());
         expectedCounterparty.setConnectionId(msg.getConnectionId());
-        expectedCounterparty.setPrefix(prefix);
 
         ConnectionEnd expectedConnection = new ConnectionEnd();
         expectedConnection.setClientId(connection.getCounterparty().getClientId());
@@ -166,13 +156,9 @@ public class IBCConnection extends IBCClient {
         int state = connection.getState();
         Context.require(state == ConnectionEnd.State.STATE_TRYOPEN, "connection state is not TRYOPEN");
 
-        MerklePrefix prefix = new MerklePrefix();
-        prefix.setKeyPrefix(commitmentPrefix);
-
         Counterparty expectedCounterparty = new Counterparty();
         expectedCounterparty.setClientId(connection.getClientId());
         expectedCounterparty.setConnectionId(msg.getConnectionId());
-        expectedCounterparty.setPrefix(prefix);
 
         ConnectionEnd expectedConnection = new ConnectionEnd();
         expectedConnection.setClientId(connection.getCounterparty().getClientId());

--- a/contracts/javascore/ibc/src/test/java/ibc/ics03/connection/ConnectionTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics03/connection/ConnectionTest.java
@@ -97,8 +97,7 @@ public class ConnectionTest extends TestBase {
         consensusHeight = Height.newBuilder()
                 .setRevisionHeight(7)
                 .setRevisionNumber(8).build();
-        prefix = MerklePrefix.newBuilder()
-                .setKeyPrefix(ByteString.copyFrom(IBCConnection.commitmentPrefix)).build();
+        prefix = MerklePrefix.newBuilder().build();
 
         counterparty = Counterparty.newBuilder()
                 .setClientId("counterpartyId")

--- a/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/ChannelHandshakeTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/ChannelHandshakeTest.java
@@ -91,8 +91,7 @@ public class ChannelHandshakeTest extends TestBase {
                 .setRevisionHeight(5)
                 .setRevisionNumber(6).build();
 
-        prefix = MerklePrefix.newBuilder()
-                .setKeyPrefix(ByteString.copyFrom(IBCConnection.commitmentPrefix)).build();
+        prefix = MerklePrefix.newBuilder().build();
 
         connectionCounterparty = Connection.Counterparty.newBuilder()
                 .setClientId(clientId)

--- a/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
@@ -95,7 +95,7 @@ public class PacketTest extends TestBase {
 
         lightClient = new MockContract<>(ILightClientScoreInterface.class, ILightClient.class, sm, owner);
 
-        prefix.setKeyPrefix(IBCConnection.commitmentPrefix);
+        prefix.setKeyPrefix(new byte[0]);
         proofHeight.setRevisionHeight(BigInteger.valueOf(5));
         proofHeight.setRevisionNumber(BigInteger.valueOf(6));
 

--- a/contracts/javascore/score-util/src/main/java/ibc/icon/score/util/Proto.java
+++ b/contracts/javascore/score-util/src/main/java/ibc/icon/score/util/Proto.java
@@ -101,7 +101,13 @@ public class Proto {
         if (item == null) {
             return new byte[0];
         }
-        return encode(order, item.encode());
+
+        byte[] encodedItem =  item.encode();
+        if (encodedItem.length == 0){
+            return new byte[] {(byte)(order << 3 | 2), 0};
+        }
+
+        return encode(order, encodedItem);
     }
 
     public static byte[] encodeStringArray(int order, List<String> items) {


### PR DESCRIPTION
Remove java commitment prefix and fix issue when ecoding nested proto messages

## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
