### PR TITLE
fix: Use string keys for return map in getPacketHeights

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCStore.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCStore.java
@@ -60,7 +60,7 @@ public abstract class IBCStore extends ModuleManager implements IIBCHost {
     public static final BranchDB<String, BranchDB<String, DictDB<BigInteger, Boolean>>> packetReceipts = Context
             .newBranchDB(PACKET_RECEIPTS, Boolean.class);
     public static final BranchDB<String, BranchDB<String, DictDB<BigInteger, Long>>> packetHeights = Context
-            .newBranchDB(PACKET_HEIGHTS, BigInteger.class);
+            .newBranchDB(PACKET_HEIGHTS, Long.class);
 
     public static final DictDB<byte[],Address> capabilities = Context.newDictDB(CAPABILITIES, Address.class);
     public static final ArrayDB<String> portIds = Context.newArrayDB(PORT_IDS, String.class);
@@ -183,14 +183,14 @@ public abstract class IBCStore extends ModuleManager implements IIBCHost {
     }
 
     @External(readonly = true)
-    public Map<BigInteger, Long> getPacketHeights(String portId, String channelId, int startSequence, int endSequence) {
+    public Map<String, Long> getPacketHeights(String portId, String channelId, int startSequence, int endSequence) {
         DictDB<BigInteger, Long> packets = packetHeights.at(portId).at(channelId);
-        Map<BigInteger, Long> heights = new HashMap<>();
+        Map<String, Long> heights = new HashMap<>();
         for (int i = startSequence; i <= endSequence; i++) {
             BigInteger sequence = BigInteger.valueOf(i);
             Long height = packets.get(sequence);
             if (height != null){
-                heights.put(sequence, height);
+                heights.put(sequence.toString(), height);
             }
         }
 

--- a/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics04/channel/PacketTest.java
@@ -283,9 +283,9 @@ public class PacketTest extends TestBase {
         verify(packetSpy).sendBTPMessage(clientId, ByteUtil.join(key2, expectedCommitment));
         assertEquals(BigInteger.valueOf(3),
                 packet.call("getNextSequenceSend", basePacket.getSourcePort(), basePacket.getSourceChannel()));
-        Map<BigInteger, Long> heights =  (Map<BigInteger, Long>)packet.call("getPacketHeights",basePacket.getSourcePort(), basePacket.getSourceChannel(), 0, 10);
-        assertNotNull(heights.get(BigInteger.ONE));
-        assertNotNull(heights.get(BigInteger.TWO));
+        Map<String, Long> heights =  (Map<String, Long>)packet.call("getPacketHeights",basePacket.getSourcePort(), basePacket.getSourceChannel(), 0, 10);
+        assertNotNull(heights.get("1"));
+        assertNotNull(heights.get("2"));
         assertEquals(heights.size(), 2);
     }
 

--- a/contracts/javascore/lib/src/main/java/ibc/icon/interfaces/IIBCHost.java
+++ b/contracts/javascore/lib/src/main/java/ibc/icon/interfaces/IIBCHost.java
@@ -1,6 +1,8 @@
 package ibc.icon.interfaces;
 
 import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
 
 import foundation.icon.score.client.ScoreClient;
 import score.Address;
@@ -66,10 +68,16 @@ public interface IIBCHost {
     byte[] getPacketCommitment(String portId, String channelId, BigInteger sequence);
 
     @External(readonly = true)
+    Map<String, Long> getPacketHeights(String portId, String channelId, int startSequence, int endSequence);
+
+    @External(readonly = true)
     byte[] getPacketAcknowledgementCommitment(String portId, String channelId, BigInteger sequence);
 
     @External(readonly = true)
     boolean hasPacketReceipt(String portId, String channelId, BigInteger sequence);
+
+    @External(readonly = true)
+    List<Integer> getMissingPacketReceipts(String portId, String channelId, int startSequence, int endSequence);
 
     @External(readonly = true)
     int getBTPNetworkId(String clientId);


### PR DESCRIPTION
## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
