### PR TITLE
feat: clone submodules to deploy java smart contracts

### DIFF
--- a/.github/workflows/uat-deploy-java-contracts.yml
+++ b/.github/workflows/uat-deploy-java-contracts.yml
@@ -11,7 +11,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Retrieve the secret and decode it to a file
         working-directory: contracts/javascore


### PR DESCRIPTION
## Description:
Currently the submodules are not cloned while running the deployment to uat ci. With this change, the submodules are also cloned to fix the error currently CI is having.

### Commit Message

```bash
feat: clone submodules to deploy java smart contracts
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [X] I only have one commit (if not, squash them into one commit).
- [X] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
