### PR TITLE
fix: Make verify membership functions readonly in tendermint lightclient

### DIFF
--- a/contracts/javascore/lightclients/mockclient/src/main/java/ibc/mockclient/MockClient.java
+++ b/contracts/javascore/lightclients/mockclient/src/main/java/ibc/mockclient/MockClient.java
@@ -61,7 +61,7 @@ public class MockClient implements ILightClient {
         );
     }
 
-    @External
+    @External(readonly = true)
     public void verifyMembership(
             String clientId,
             byte[] heightBytes,
@@ -73,7 +73,7 @@ public class MockClient implements ILightClient {
             byte[] value) {
     }
 
-    @External
+    @External(readonly = true)
     public void verifyNonMembership(
             String clientId,
             byte[] heightBytes,

--- a/contracts/javascore/lightclients/tendermint/src/main/java/ibc/tendermint/TendermintLightClient.java
+++ b/contracts/javascore/lightclients/tendermint/src/main/java/ibc/tendermint/TendermintLightClient.java
@@ -193,7 +193,7 @@ public class TendermintLightClient extends Tendermint implements ILightClient {
                 "height", newHeight(clientState.getLatestHeight()).encode());
     }
 
-    @External
+    @External(readonly = true)
     public void verifyMembership(
             String clientId,
             byte[] heightBytes,
@@ -222,7 +222,7 @@ public class TendermintLightClient extends Tendermint implements ILightClient {
         Merkle.verifyMembership(merkleProof, Merkle.getSDKSpecs(), root, merklePath, value);
     }
 
-    @External
+    @External(readonly = true)
     public void verifyNonMembership(
             String clientId,
             byte[] heightBytes,


### PR DESCRIPTION
## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
