### PR TITLE
fix: Only allow connection to be in INIT state during connectionOpenAck

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics03/connection/IBCConnection.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics03/connection/IBCConnection.java
@@ -98,17 +98,10 @@ public class IBCConnection extends IBCClient {
 
         int state = connection.getState();
         // TODO should we allow the state to be TRY_OPEN?
-        Context.require(state == ConnectionEnd.State.STATE_INIT || state == ConnectionEnd.State.STATE_TRYOPEN,
-                "connection state is not INIT or TRYOPEN");
-        if (state == ConnectionEnd.State.STATE_INIT) {
-            Context.require(isSupportedVersion(Version.decode(msg.getVersion())),
-                    "connection state is in INIT but the provided version is not supported");
-        } else {
-            Context.require(
-                    connection.getVersions().size() == 1
-                            && Arrays.equals(connection.getVersions().get(0).encode(), msg.getVersion()),
-                    "connection state is in TRYOPEN but the provided version is not set in the previous connection versions");
-        }
+        Context.require(state == ConnectionEnd.State.STATE_INIT, "connection state is not INIT");
+        Context.require(isSupportedVersion(Version.decode(msg.getVersion())),
+                "connection state is in INIT but the provided version is not supported");
+
 
         // TODO: investigate need to self client validation
         // require(validateSelfClient(msg.clientStateBytes), "failed to validate self

--- a/contracts/javascore/ibc/src/test/java/ibc/ics03/connection/ConnectionTest.java
+++ b/contracts/javascore/ibc/src/test/java/ibc/ics03/connection/ConnectionTest.java
@@ -269,28 +269,7 @@ public class ConnectionTest extends TestBase {
         msg.setConnectionId("connection-0");
 
         // Act & Assert
-        String expectedErrorMessage = "connection state is not INIT or TRYOPEN";
-        Executable clientVerificationFailed = () -> connection.invoke(owner,
-                "_connectionOpenAck", msg);
-        AssertionError e = assertThrows(AssertionError.class,
-                clientVerificationFailed);
-        assertTrue(e.getMessage().contains(expectedErrorMessage));
-    }
-
-    @Test
-    void connectionOpenAck_wrongVersion() {
-        // Arrange
-        connectionOpenTry();
-        MsgConnectionOpenAck msg = new MsgConnectionOpenAck();
-        msg.setConnectionId("connection-0");
-        Version wrongVersion = Version.newBuilder()
-                .setIdentifier("OtherVersion")
-                .addFeatures("some features").build();
-        msg.setVersion(wrongVersion.toByteArray());
-
-        // Act & Assert
-        String expectedErrorMessage = "connection state is in TRYOPEN but the provided version is not set in the " +
-                "previous connection versions";
+        String expectedErrorMessage = "connection state is not INIT";
         Executable clientVerificationFailed = () -> connection.invoke(owner,
                 "_connectionOpenAck", msg);
         AssertionError e = assertThrows(AssertionError.class,


### PR DESCRIPTION

## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
