### PR TITLE
fix: Use built in Arrays.equals instead of our own version

### DIFF
--- a/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics04/channel/IBCPacket.java
@@ -13,6 +13,7 @@ import score.Context;
 import score.DictDB;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 
 // TODO verify packet commitments follow a correct format
 public class IBCPacket extends IBCChannelHandshake {
@@ -172,7 +173,7 @@ public class IBCPacket extends IBCChannelHandshake {
         Context.require(packetCommitment != null, "packet commitment not found");
         byte[] commitment = createPacketCommitment(packet);
 
-        Context.require(IBCCommitment.equals(packetCommitment, commitment), "commitment byte[] are not equal");
+        Context.require(Arrays.equals(packetCommitment, commitment), "commitment byte[] are not equal");
 
         byte[] packetAckPath = IBCCommitment.packetAcknowledgementCommitmentPath(packet.getDestinationPort(),
                 packet.getDestinationChannel(), packet.getSequence());
@@ -300,7 +301,7 @@ public class IBCPacket extends IBCChannelHandshake {
         Context.require(packetCommitment != null, "packet commitment not found");
         byte[] commitment = createPacketCommitment(packet);
 
-        Context.require(IBCCommitment.equals(packetCommitment, commitment), "commitment byte[] are not equal");
+        Context.require(Arrays.equals(packetCommitment, commitment), "commitment byte[] are not equal");
 
         if (channel.getOrdering() == Channel.Order.ORDER_UNORDERED) {
             byte[] packetReceiptKey = IBCCommitment.packetReceiptCommitmentPath(

--- a/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCCommitment.java
+++ b/contracts/javascore/ibc/src/main/java/ibc/ics24/host/IBCCommitment.java
@@ -88,17 +88,4 @@ public class IBCCommitment {
     public static byte[] nextSequenceRecvCommitmentKey(String portId, String channelId) {
         return Context.hash(KECCAK256, nextSequenceRecvCommitmentPath(portId, channelId));
     }
-
-    public static boolean equals(byte[] a, byte[] b) {
-        boolean isEqual;
-        int length = a.length;
-        isEqual = length == b.length;
-
-        for (int i = 0; isEqual && (i < length); ++i) {
-            isEqual = (a[i] == b[i]);
-        }
-
-        return isEqual;
-    }
-
 }


### PR DESCRIPTION
## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
