### PR TITLE
fix: icon client add prev consensus height method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ debug/
 target/
 artifacts/*
 
+report/**
+
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
 #Cargo.lock

--- a/contracts/cosmwasm-vm/cw-common/src/client_msg.rs
+++ b/contracts/cosmwasm-vm/cw-common/src/client_msg.rs
@@ -77,7 +77,7 @@ pub enum QueryMsg {
     VerifyConnectionOpenTry(VerifyConnectionPayload),
     #[returns(bool)]
     VerifyConnectionOpenAck(VerifyConnectionPayload),
-    #[returns(Vec<u8>)]
+    #[returns(Vec<u64>)]
     GetPreviousConsensusState { client_id: String, height: u64 },
 }
 

--- a/contracts/cosmwasm-vm/cw-common/src/core_msg.rs
+++ b/contracts/cosmwasm-vm/cw-common/src/core_msg.rs
@@ -205,4 +205,6 @@ pub enum QueryMsg {
         start_sequence: u64,
         end_sequence: u64,
     },
+    #[returns(Vec<u64>)]
+    GetPreviousConsensusStateHeight { client_id: String, height: u64 },
 }

--- a/contracts/cosmwasm-vm/cw-ibc-core/src/contract.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/src/contract.rs
@@ -500,6 +500,14 @@ impl<'a> CwIbcCoreContext<'a> {
                     .unwrap();
                 to_binary(&missing)
             }
+            QueryMsg::GetPreviousConsensusStateHeight { client_id, height } => {
+                let client_val = IbcClientId::from_str(&client_id).unwrap();
+                let client = self.get_client(deps.storage, &client_val).unwrap();
+                let res = client
+                    .get_previous_consensus_state(deps, &client_val, height)
+                    .unwrap();
+                to_binary(&res)
+            }
         }
     }
 

--- a/contracts/cosmwasm-vm/cw-ibc-core/src/light_client/light_client.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/src/light_client/light_client.rs
@@ -208,4 +208,23 @@ impl LightClient {
         let response: Vec<u8> = deps.querier.query(&query).map_err(ContractError::Std)?;
         Ok(response)
     }
+
+    pub fn get_previous_consensus_state(
+        &self,
+        deps: Deps,
+        client_id: &IbcClientId,
+        height: u64,
+    ) -> Result<Vec<u64>, ContractError> {
+        let query_message = cw_common::client_msg::QueryMsg::GetPreviousConsensusState {
+            client_id: client_id.as_str().to_string(),
+            height,
+        };
+        let msg = to_binary(&query_message).map_err(ContractError::Std)?;
+
+        let query = build_smart_query(self.address.clone(), msg);
+
+        let response: Vec<u64> = deps.querier.query(&query).map_err(ContractError::Std)?;
+
+        Ok(response)
+    }
 }

--- a/contracts/cosmwasm-vm/cw-icon-light-client/src/contract.rs
+++ b/contracts/cosmwasm-vm/cw-icon-light-client/src/contract.rs
@@ -493,7 +493,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_binary(&(is_channel_valid && _sequence_valid))
         }
         QueryMsg::GetPreviousConsensusState { client_id, height } => {
-            let res =
+            let res: Vec<u64> =
                 QueryHandler::get_previous_consensus(deps.storage, height, client_id).unwrap();
             to_binary(&res)
         }


### PR DESCRIPTION
## Description:
A method to return prev consensus height with respect to provided height was added in ibc-core. 

### Commit Message

```bash
fix: icon client add prev consensus height method.
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
