### PR TITLE
fix: send packet height is not set to zero during timeout packet

### DIFF
--- a/contracts/cosmwasm-vm/cw-common/src/xcall_connection_msg.rs
+++ b/contracts/cosmwasm-vm/cw-common/src/xcall_connection_msg.rs
@@ -64,7 +64,6 @@ pub enum ExecuteMsg {
     },
 }
 
-
 #[cw_serde]
 pub struct ConfigResponse {
     pub channel_id: String,

--- a/contracts/cosmwasm-vm/cw-ibc-core/src/ics04_channel/packet/timeout.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/src/ics04_channel/packet/timeout.rs
@@ -165,6 +165,14 @@ impl<'a> CwIbcCoreContext<'a> {
             &src_channel,
             packet.sequence.into(),
         )?;
+        // reset height to zero once packet has timed out
+        self.ibc_store().store_sent_packet(
+            deps.storage,
+            &src_port,
+            &src_channel,
+            packet.sequence,
+            0,
+        )?;
 
         if let Order::Ordered = channel_end.ordering {
             channel_end.state = State::Closed;

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/contract.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/contract.rs
@@ -17,9 +17,8 @@ use crate::{
         XCALL_HANDLE_ERROR_REPLY_ID, XCALL_HANDLE_MESSAGE_REPLY_ID,
     },
     types::{
-        channel_config::ChannelConfig, config::Config, connection_config::ConnectionConfig,
-        config_response::to_config_response,
-        message::Message, LOG_PREFIX,
+        channel_config::ChannelConfig, config::Config, config_response::to_config_response,
+        connection_config::ConnectionConfig, message::Message, LOG_PREFIX,
     },
 };
 

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/contract.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/contract.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use common::{
     ibc::Height,
     rlp::{self},

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/types/config_response.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/types/config_response.rs
@@ -1,7 +1,7 @@
 use cw_common::xcall_connection_msg::ConfigResponse;
 
-use crate::types::channel_config::ChannelConfig;
 use crate::state::IbcConfig;
+use crate::types::channel_config::ChannelConfig;
 
 pub fn to_config_response(ibc_config: IbcConfig, channel_config: ChannelConfig) -> ConfigResponse {
     ConfigResponse {

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/types/config_response.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/types/config_response.rs
@@ -10,6 +10,6 @@ pub fn to_config_response(ibc_config: IbcConfig, channel_config: ChannelConfig) 
         destination_channel_id: ibc_config.dst_endpoint().channel_id.clone(),
         destination_port_id: ibc_config.dst_endpoint().port_id.clone(),
         light_client_id: channel_config.client_id,
-        timeout_height: channel_config.timeout_height.clone(),
+        timeout_height: channel_config.timeout_height,
     }
 }

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/types/mod.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/types/mod.rs
@@ -2,8 +2,8 @@ pub mod storage_keys;
 pub use common::rlp;
 
 pub mod channel_config;
-pub mod config_response;
 pub mod config;
+pub mod config_response;
 pub mod connection_config;
 pub mod message;
 pub mod network_fees;


### PR DESCRIPTION
## Description:

### Commit Message

```bash
fix: send packet height is not set to zero during timeout packet 
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
0.1.0: Set height zero when packet times out
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
