### PR TITLE
feat: add library feature for xcall ibc connection

### DIFF
--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/lib.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/lib.rs
@@ -66,7 +66,7 @@ use thiserror::Error;
 ///
 /// The `instantiate` function returns a `Result<Response, ContractError>` which represents either a
 /// successful response or an error.
-#[entry_point]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
     env: Env,


### PR DESCRIPTION
## Description
The instantiate entry point is not marked as library

### Commit Message

```bash
feat: add library feature for xcall ibc connection
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [X] I only have one commit (if not, squash them into one commit).
- [X] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)
- [ ] I have added version bump label on PR.

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
