### PR TITLE
fix: ibc query method get consensus state by height should return any type

### DIFF
--- a/contracts/cosmwasm-vm/cw-ibc-core/src/contract.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/src/contract.rs
@@ -290,10 +290,9 @@ impl<'a> CwIbcCoreContext<'a> {
                 let client_val = IbcClientId::from_str(&client_id).unwrap();
                 let client = self.get_light_client(deps.storage, &client_val).unwrap();
                 let res = client
-                    .get_consensus_state(deps, &client_val, height)
+                    .get_consensus_state_any(deps, &client_val, height)
                     .unwrap();
-                let state = res.as_bytes();
-                to_binary(&hex::encode(state))
+                to_binary(&hex::encode(res.encode_to_vec()))
             }
             QueryMsg::GetClientState { client_id } => {
                 let res = self

--- a/contracts/cosmwasm-vm/cw-ibc-core/src/contract.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/src/contract.rs
@@ -292,6 +292,7 @@ impl<'a> CwIbcCoreContext<'a> {
                 let res = client
                     .get_consensus_state_any(deps, &client_val, height)
                     .unwrap();
+
                 to_binary(&hex::encode(res.encode_to_vec()))
             }
             QueryMsg::GetClientState { client_id } => {


### PR DESCRIPTION

## Description

IBC query method get consensus state by height should return any type consensus state 

### Commit Message

```bash
fix: ibc query method get consensus state by height should return a…
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)
- [ ] I have added version bump label on PR.

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
