### PR TITLE
fix: do not send fund to ibc core on send_call_message

### DIFF
--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/fee.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/fee.rs
@@ -14,7 +14,7 @@ impl<'a> CwIbcConnection<'a> {
         nid: NetId,
         address: String,
     ) -> Result<SubMsg, ContractError> {
-        let caller = info.sender.clone();
+        let caller = info.sender;
         let fees = self.get_unclaimed_packet_fee(deps.as_ref().storage, &nid, caller.as_ref());
         if fees == 0 {
             return Err(ContractError::NoFeesAccrued);
@@ -31,7 +31,7 @@ impl<'a> CwIbcConnection<'a> {
         let timeout_height =
             self.query_timeout_height(deps.as_ref(), &ibc_config.src_endpoint().channel_id)?;
         let packet = self.create_packet(ibc_config, timeout_height, sequence_no, message);
-        let sub_msg = self.call_host_send_message(deps, info, packet)?;
+        let sub_msg = self.call_host_send_message(deps, packet)?;
         Ok(sub_msg)
     }
 

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/ibc_host.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/ibc_host.rs
@@ -1,7 +1,7 @@
 use crate::state::IbcConfig;
 use crate::types::LOG_PREFIX;
 use common::ibc::Height;
-use cosmwasm_std::{to_binary, CosmosMsg, Deps, DepsMut, MessageInfo, Storage, SubMsg, WasmMsg};
+use cosmwasm_std::{to_binary, CosmosMsg, Deps, DepsMut, Storage, SubMsg, WasmMsg};
 use cw_common::cw_types::CwPacket;
 use cw_common::query_helpers::build_smart_query;
 use cw_common::{hex_string::HexString, raw_types::channel::RawPacket, ProstMessage};
@@ -45,7 +45,6 @@ impl<'a> CwIbcConnection<'a> {
     pub fn call_host_send_message(
         &self,
         deps: DepsMut,
-        info: MessageInfo,
         packet: RawPacket,
     ) -> Result<SubMsg, ContractError> {
         let message = cw_common::core_msg::ExecuteMsg::SendPacket {
@@ -57,7 +56,7 @@ impl<'a> CwIbcConnection<'a> {
             msg: CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: ibc_host.to_string(),
                 msg: to_binary(&message).map_err(ContractError::Std)?,
-                funds: info.funds,
+                funds: vec![],
             }),
             gas_limit: None,
             reply_on: cosmwasm_std::ReplyOn::Always,
@@ -111,7 +110,7 @@ mod tests {
     use cosmwasm_std::{
         coin,
         testing::{mock_dependencies_with_balance, mock_env},
-        to_binary, Addr, CosmosMsg, MessageInfo, SubMsg, WasmMsg,
+        to_binary, Addr, CosmosMsg, SubMsg, WasmMsg,
     };
     use cw_common::{hex_string::HexString, raw_types::channel::RawPacket, ProstMessage};
 
@@ -128,14 +127,11 @@ mod tests {
         connection
             .set_ibc_host(store, Addr::unchecked("ibc-host"))
             .unwrap();
-        let env = mock_env();
-        let info = MessageInfo {
-            sender: env.contract.address,
-            funds: vec![coin(100, "ATOM")],
-        };
+        let _env = mock_env();
+
         let packet = RawPacket::default();
 
-        let res = connection.call_host_send_message(deps.as_mut(), info, packet.clone());
+        let res = connection.call_host_send_message(deps.as_mut(), packet.clone());
         println!("{:?}", res);
         assert!(res.is_ok());
 

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/ibc_host.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/ibc_host.rs
@@ -147,7 +147,7 @@ mod tests {
             msg: CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: expected_ibc_host,
                 msg: to_binary(&expected_message).unwrap(),
-                funds: vec![coin(100, "ATOM")],
+                funds: vec![],
             }),
             gas_limit: None,
             reply_on: cosmwasm_std::ReplyOn::Always,

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/send_message.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/send_message.rs
@@ -18,7 +18,7 @@ impl<'a> CwIbcConnection<'a> {
         sn: i64,
         message: Vec<u8>,
     ) -> Result<Response, ContractError> {
-        self.ensure_xcall_handler(deps.as_ref().storage, info.sender.clone())?;
+        self.ensure_xcall_handler(deps.as_ref().storage, info.sender)?;
 
         println!("{LOG_PREFIX} Packet Validated");
         let ibc_config = self.get_ibc_config(deps.as_ref().storage, &nid)?;
@@ -66,7 +66,7 @@ impl<'a> CwIbcConnection<'a> {
 
             println!("{} Raw Packet Created {:?}", LOG_PREFIX, &packet_data);
 
-            let submessage = self.call_host_send_message(deps, info, packet_data)?;
+            let submessage = self.call_host_send_message(deps, packet_data)?;
             Ok(Response::new()
                 .add_submessage(submessage)
                 .add_attribute("method", "send_message"))


### PR DESCRIPTION
## Description
Do not send fund to IBC host on send_call_message

### Commit Message

```bash
fix: do not send fund to ibc core on send_call_message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)
- [x] I have added version bump label on PR.

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
