### PR TITLE
fix: Add seperate varint decoder which handles long values

### DIFF
--- a/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/LightClientTest.java
+++ b/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/LightClientTest.java
@@ -118,6 +118,25 @@ public class LightClientTest extends LightClientTestBase {
     }
 
     @Test
+    void updateValidatorWithLargePower() throws Exception {
+        // Arrange
+        blockSetPath = BLOCK_SET_LONG_POWER;
+        SignedHeader lastHeader = parseSignedHeader(3);
+
+        // Act
+        initializeClient(1);
+        updateClient(2, 1);
+        updateClient(3, 2);
+
+        // Assert
+        ClientState clientState = getClientState();
+        assertEquals(clientState.getLatestHeight(), lastHeader.getHeader().getHeight());
+        assertConsensusState(parseSignedHeader(1));
+        assertConsensusState(parseSignedHeader(2));
+        assertConsensusState(lastHeader);
+    }
+
+    @Test
     void updateAdjacentBlocks() throws Exception {
         // Arrange
         blockSetPath = BLOCK_SET_ADJACENT;

--- a/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/LightClientTestBase.java
+++ b/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/LightClientTestBase.java
@@ -71,6 +71,7 @@ public class LightClientTestBase extends TestBase {
     protected static final String BLOCK_SET_MUTILPLE_VALIDATORS = BLOCK_SET_BASE_PATH + "multi-validator/";
     protected static final String BLOCK_SET_ADJACENT = BLOCK_SET_BASE_PATH + "adjacent/";
     protected static final String BLOCK_SET_MALICIOUS = BLOCK_SET_BASE_PATH + "malicious/";
+    protected static final String BLOCK_SET_LONG_POWER = BLOCK_SET_BASE_PATH + "validator-with-long-voting-power/";
     protected String blockSetPath = BLOCK_SET_SIMPLE;
 
     static {

--- a/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/commit.1.json
+++ b/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/commit.1.json
@@ -1,0 +1,72 @@
+{
+    "signed_header": {
+        "header": {
+            "version": {
+                "block": "11"
+            },
+            "chain_id": "injective-888",
+            "height": "17920038",
+            "time": "2023-11-02T13:33:21.027116706Z",
+            "last_block_id": {
+                "hash": "C08020E636E8C907A70003E6D65E066AD80F5EB460D9872CF6E27BF4737859BF",
+                "parts": {
+                    "total": 1,
+                    "hash": "CD289D26FD3291FFCB3D26A2AA70409CE6A49F0A5A9B9655B9C3105211FD2C6E"
+                }
+            },
+            "last_commit_hash": "5F2FF8F52ACA9C21601B689D27EDD5FDB8FD31926B674A512ABE3406921D5E83",
+            "data_hash": "ADF4E59E6EDDF65C7A37AB51A5B90228816E6F3A46A9AB6C4291ABE5AF5C0DD8",
+            "validators_hash": "E947FC8185006455AE3606D4F1CA18097AD3E352C76D2F405D6DF3509BC84A45",
+            "next_validators_hash": "E947FC8185006455AE3606D4F1CA18097AD3E352C76D2F405D6DF3509BC84A45",
+            "consensus_hash": "E5BBA9239C0D3F967F8EF879506FF6EBDFB940F8904D7291351A461F00AAAD4D",
+            "app_hash": "9C4104E2CD45CA1B26EE54E43E2CAFAF73C3D3BC4A1D1759A7B5E5E234150C14",
+            "last_results_hash": "279D27AC52700DCF9F02609C1912CD90D76A217D8AB00843598177E99B73F5A8",
+            "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "proposer_address": "3391E35B61004E03BEB88FA1DAB4444B913BD7BE"
+        },
+        "commit": {
+            "height": "17920038",
+            "round": 0,
+            "block_id": {
+                "hash": "67C262CBA5552BAB48AEF8B09D5E80907B2014D0D45EB6665D11A7E3848E3381",
+                "parts": {
+                    "total": 1,
+                    "hash": "302AF52F2B1AE2F23DF50351F56EEB9797E0F14474D14DBB403EBB92425F12AF"
+                }
+            },
+            "signatures": [
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "3391E35B61004E03BEB88FA1DAB4444B913BD7BE",
+                    "timestamp": "2023-11-02T13:33:23.442609428Z",
+                    "signature": "7cUkUt2IRrQ88cT7BTJ20wpQQOAx1vOOGXAHCHZEO5hH8cl8yJd6lQ7fkQ95mSgvTSKkTiefVcGAhXY3DhwcAA=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "36FF1CB8B136E4BE26827071F2C842986EBCC5F7",
+                    "timestamp": "2023-11-02T13:33:23.441884438Z",
+                    "signature": "vzkh7jwM7asuWXvsWS7qGSwD8iQoyo2uZwJH0GKDvoUHSk/hr4yHU8qrQh0+QtlA/TKVgWrPkOFAqxWIDmczAQ=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "39B51761D4BC8DF4D234FA2750114F2647EDEDE0",
+                    "timestamp": "2023-11-02T13:33:23.342446104Z",
+                    "signature": "sVPZebPvRFW8Ffn08S3p8FtLI/cDezRWA4ZIabCKzsn/bjw3lGJTgsCamPEfVoAW258KwVHOqa0+99weF/asBQ=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "CBC72D2784292744BB653558ED14C4E33D614B67",
+                    "timestamp": "2023-11-02T13:33:23.347423377Z",
+                    "signature": "8WgFInmQutXqp96VAQ8CrMoptrUOUUJADtntuNl2ybUbVlGdDXD7090NlHFpiGcOMrHb/QdrpyMF5363YSjeCQ=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "2CBA0C86B9BE7034D7BD2F02C1A5FEDFE1FAD2D8",
+                    "timestamp": "2023-11-02T13:33:23.605327672Z",
+                    "signature": "ZvcrZitOEbPbb9GEaZB36bBoN+ohXBCTkZBKm2ZBWevOVdSXdU9WzuIDhK15CPmYuQgVNUWavUZXEZ1Wsmz8Aw=="
+                }
+            ]
+        }
+    },
+    "canonical": true
+}

--- a/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/commit.2.json
+++ b/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/commit.2.json
@@ -1,0 +1,72 @@
+{
+    "signed_header": {
+        "header": {
+            "version": {
+                "block": "11"
+            },
+            "chain_id": "injective-888",
+            "height": "17920039",
+            "time": "2023-11-02T13:33:23.441884438Z",
+            "last_block_id": {
+                "hash": "67C262CBA5552BAB48AEF8B09D5E80907B2014D0D45EB6665D11A7E3848E3381",
+                "parts": {
+                    "total": 1,
+                    "hash": "302AF52F2B1AE2F23DF50351F56EEB9797E0F14474D14DBB403EBB92425F12AF"
+                }
+            },
+            "last_commit_hash": "62ABAAA7AFE658FDF3298F1EBD134B172A6C3D3DBDE00B7A8D99A5ADED077843",
+            "data_hash": "143A710FE20ACCFE5CE1D12E9420F854EFB2C92E00EB80EE813F162C7E6200D5",
+            "validators_hash": "E947FC8185006455AE3606D4F1CA18097AD3E352C76D2F405D6DF3509BC84A45",
+            "next_validators_hash": "E947FC8185006455AE3606D4F1CA18097AD3E352C76D2F405D6DF3509BC84A45",
+            "consensus_hash": "E5BBA9239C0D3F967F8EF879506FF6EBDFB940F8904D7291351A461F00AAAD4D",
+            "app_hash": "AFE74B9B502591D084C6E899B756A248EADF7E273BCBF3C6D82D482BFD2EFB8A",
+            "last_results_hash": "CC759FD069BB67EF291E281E710B4B846CF1DCFD459FFBF7706BD6D1B9A828EB",
+            "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "proposer_address": "36FF1CB8B136E4BE26827071F2C842986EBCC5F7"
+        },
+        "commit": {
+            "height": "17920039",
+            "round": 0,
+            "block_id": {
+                "hash": "AA76FDD15D36BE82CB3C4232E7ADBAC5A46363725DCB3239B7470E5801405BDA",
+                "parts": {
+                    "total": 1,
+                    "hash": "1CE121BB7F8B9C91A6AA4D2AF1F221E72B11ED88F174BB224CC17583CC7CB8DA"
+                }
+            },
+            "signatures": [
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "3391E35B61004E03BEB88FA1DAB4444B913BD7BE",
+                    "timestamp": "2023-11-02T13:33:25.645542243Z",
+                    "signature": "HtctXHea3ma7xqHuBldAq2bQX7YpQb9rxuxavwHg/B4x6+TtKZLe/E7gloLizC2mxrOEJ6iXBMJfZ9GYiLesDA=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "36FF1CB8B136E4BE26827071F2C842986EBCC5F7",
+                    "timestamp": "2023-11-02T13:33:25.656553715Z",
+                    "signature": "QepzfO1DNtIQW62LN683OUW7n2o/KRkEFjBFK7OqAarMSLZNqhJxZ/k2W1KaZJHz8Jybw1Y2MAT300g70CYjDw=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "39B51761D4BC8DF4D234FA2750114F2647EDEDE0",
+                    "timestamp": "2023-11-02T13:33:25.658405119Z",
+                    "signature": "Wg+ipzg9zYtRvIEZ9CeTyiT6bXFPbsaYttTBFpU0sHCzVuDcP+6ktLiWoY1aIIHtfiPVOAqQQpn6EIWkvqZ+DQ=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "CBC72D2784292744BB653558ED14C4E33D614B67",
+                    "timestamp": "2023-11-02T13:33:25.645294352Z",
+                    "signature": "VEboNAJyPm42pVUc6YsqyeRWFyKCM66SpWYrV6Q9Uk0aiEJ1WDBrbTnLsjkOmJJKCz2yF+OHv43RKq/DLOlYBQ=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "2CBA0C86B9BE7034D7BD2F02C1A5FEDFE1FAD2D8",
+                    "timestamp": "2023-11-02T13:33:25.820218014Z",
+                    "signature": "uc+YW3uiqDA6n4xjRgawH8oY27yiYa3aw1gKEiQqslkLACm6rvild+mwqITVX0dJCzM+EZGpPMZqOlGOk9S2BQ=="
+                }
+            ]
+        }
+    },
+    "canonical": true
+}

--- a/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/commit.3.json
+++ b/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/commit.3.json
@@ -1,0 +1,72 @@
+{
+    "signed_header": {
+        "header": {
+            "version": {
+                "block": "11"
+            },
+            "chain_id": "injective-888",
+            "height": "17920086",
+            "time": "2023-11-02T13:35:02.047390058Z",
+            "last_block_id": {
+                "hash": "347BE8943E602C19DAC7185E926EDC4DBA096BA20A417D8CF3381BDCA948A649",
+                "parts": {
+                    "total": 1,
+                    "hash": "BEE955F8690D6EA3A945F213B9CBDCCF288391C08928986751EF81E6CAFEF42B"
+                }
+            },
+            "last_commit_hash": "D582AC642827C533166497DE555730DC3A30F82EDE41E94AB9520BDF56A1DC87",
+            "data_hash": "8403500554D652B74C08E70DBE91A13BD4EFF700B7670AFD9DEE68BD169BB1D9",
+            "validators_hash": "E947FC8185006455AE3606D4F1CA18097AD3E352C76D2F405D6DF3509BC84A45",
+            "next_validators_hash": "E947FC8185006455AE3606D4F1CA18097AD3E352C76D2F405D6DF3509BC84A45",
+            "consensus_hash": "E5BBA9239C0D3F967F8EF879506FF6EBDFB940F8904D7291351A461F00AAAD4D",
+            "app_hash": "C45F52638BECEDAA7C8DDE1380C3EBECD9DE86B55260576A2531B0301D39C936",
+            "last_results_hash": "D750BEF56A672385C2ECD2DBB2161FFF0AB8A1814CE6B18A229377A95F45E329",
+            "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "proposer_address": "3391E35B61004E03BEB88FA1DAB4444B913BD7BE"
+        },
+        "commit": {
+            "height": "17920086",
+            "round": 0,
+            "block_id": {
+                "hash": "C5FC14C1B1395314AA208B610A516B4679486A38D5074887D53C990FC35C212B",
+                "parts": {
+                    "total": 1,
+                    "hash": "731E65E02962832F2F1FCCA0F856D82840F9785CD83FA4DDC0729C2100C5FE55"
+                }
+            },
+            "signatures": [
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "3391E35B61004E03BEB88FA1DAB4444B913BD7BE",
+                    "timestamp": "2023-11-02T13:35:04.368632789Z",
+                    "signature": "rMzn9p/2xwscq4BW29QKUxq5G2IzzxwarlUOWkE4S/JV1r2WlSfiwZqjfORqK+fSOI5bbkaIR99dh22ZwcRwDw=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "36FF1CB8B136E4BE26827071F2C842986EBCC5F7",
+                    "timestamp": "2023-11-02T13:35:04.367578967Z",
+                    "signature": "WmPCYXNO32DcCaYpqTC2dEKthLyVpCYwmkVLKPmHGsblAQk1swHtHRITHnDlaShSjqQ5Tch/YlMxyINOsdOJCA=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "39B51761D4BC8DF4D234FA2750114F2647EDEDE0",
+                    "timestamp": "2023-11-02T13:35:04.367406356Z",
+                    "signature": "itVX4sSqUnuQcqnKud1a2Dv+LJQiU0jCdXl/+BEZfMUqAhtSnwQOSPK96LPzOiLBcdvrluM4SLK3Lz2KtqWPBQ=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "CBC72D2784292744BB653558ED14C4E33D614B67",
+                    "timestamp": "2023-11-02T13:35:04.371872862Z",
+                    "signature": "7QlwrUBp31unqQwcm051usk+jrhDFEgBCjGTc7kWffLsotiW8pKTxqv0lzao8uF//X/Rc0bM3tC2zNkQQRJqBA=="
+                },
+                {
+                    "block_id_flag": 2,
+                    "validator_address": "2CBA0C86B9BE7034D7BD2F02C1A5FEDFE1FAD2D8",
+                    "timestamp": "2023-11-02T13:35:04.621696944Z",
+                    "signature": "HbIOEh15/7Q0vn+WHb7NgTuO6HkAnV6+ycfGz+WeLO/W081/6llsnQyHQMFjcegbCphM+KWKRys/KwC7frOkBQ=="
+                }
+            ]
+        }
+    },
+    "canonical": true
+}

--- a/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/validators.1.json
+++ b/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/validators.1.json
@@ -1,0 +1,52 @@
+{
+    "block_height": "17920038",
+    "validators": [
+        {
+            "address": "3391E35B61004E03BEB88FA1DAB4444B913BD7BE",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Puku/I45dAZ4wKeN+rbYKnmuUUA7Yh7/TrKX3ZoTmk4="
+            },
+            "voting_power": "200058118992377",
+            "proposer_priority": "-132697491409996"
+        },
+        {
+            "address": "36FF1CB8B136E4BE26827071F2C842986EBCC5F7",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Bi/7vbVB1uj/zz40/aozZOvVBFkV6hLqqxBIQr5kSc4="
+            },
+            "voting_power": "200001135854983",
+            "proposer_priority": "461765604364692"
+        },
+        {
+            "address": "39B51761D4BC8DF4D234FA2750114F2647EDEDE0",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "WlL4lTR+iTbd0rn3xP6oH0juOnGRZ+Hh73Oj6/Lt/Wg="
+            },
+            "voting_power": "200000136407721",
+            "proposer_priority": "-42343657761476"
+        },
+        {
+            "address": "CBC72D2784292744BB653558ED14C4E33D614B67",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "1mF7OEpB9A60O0e+64pICbqS/nN8VnsVfoySMEW2w1Q="
+            },
+            "voting_power": "199825725805690",
+            "proposer_priority": "433172150149401"
+        },
+        {
+            "address": "2CBA0C86B9BE7034D7BD2F02C1A5FEDFE1FAD2D8",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "eUvXue8zslf+dC4TxNBXVIzMZzf6CtwagwObU6rQxb4="
+            },
+            "voting_power": "7",
+            "proposer_priority": "-719896605342617"
+        }
+    ],
+    "count": "5",
+    "total": "5"
+}

--- a/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/validators.2.json
+++ b/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/validators.2.json
@@ -1,0 +1,52 @@
+{
+    "block_height": "17920039",
+    "validators": [
+        {
+            "address": "3391E35B61004E03BEB88FA1DAB4444B913BD7BE",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Puku/I45dAZ4wKeN+rbYKnmuUUA7Yh7/TrKX3ZoTmk4="
+            },
+            "voting_power": "200058118992377",
+            "proposer_priority": "67360627582381"
+        },
+        {
+            "address": "36FF1CB8B136E4BE26827071F2C842986EBCC5F7",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Bi/7vbVB1uj/zz40/aozZOvVBFkV6hLqqxBIQr5kSc4="
+            },
+            "voting_power": "200001135854983",
+            "proposer_priority": "-138118376841103"
+        },
+        {
+            "address": "39B51761D4BC8DF4D234FA2750114F2647EDEDE0",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "WlL4lTR+iTbd0rn3xP6oH0juOnGRZ+Hh73Oj6/Lt/Wg="
+            },
+            "voting_power": "200000136407721",
+            "proposer_priority": "157656478646245"
+        },
+        {
+            "address": "CBC72D2784292744BB653558ED14C4E33D614B67",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "1mF7OEpB9A60O0e+64pICbqS/nN8VnsVfoySMEW2w1Q="
+            },
+            "voting_power": "199825725805690",
+            "proposer_priority": "632997875955091"
+        },
+        {
+            "address": "2CBA0C86B9BE7034D7BD2F02C1A5FEDFE1FAD2D8",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "eUvXue8zslf+dC4TxNBXVIzMZzf6CtwagwObU6rQxb4="
+            },
+            "voting_power": "7",
+            "proposer_priority": "-719896605342610"
+        }
+    ],
+    "count": "5",
+    "total": "5"
+}

--- a/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/validators.3.json
+++ b/contracts/javascore/lightclients/tendermint/src/test/java/ibc/tendermint/data/validator-with-long-voting-power/validators.3.json
@@ -1,0 +1,52 @@
+{
+    "block_height": "17920086",
+    "validators": [
+        {
+            "address": "3391E35B61004E03BEB88FA1DAB4444B913BD7BE",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Puku/I45dAZ4wKeN+rbYKnmuUUA7Yh7/TrKX3ZoTmk4="
+            },
+            "voting_power": "200058118992377",
+            "proposer_priority": "-128529184505236"
+        },
+        {
+            "address": "36FF1CB8B136E4BE26827071F2C842986EBCC5F7",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Bi/7vbVB1uj/zz40/aozZOvVBFkV6hLqqxBIQr5kSc4="
+            },
+            "voting_power": "200001135854983",
+            "proposer_priority": "463198720674540"
+        },
+        {
+            "address": "39B51761D4BC8DF4D234FA2750114F2647EDEDE0",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "WlL4lTR+iTbd0rn3xP6oH0juOnGRZ+Hh73Oj6/Lt/Wg="
+            },
+            "voting_power": "200000136407721",
+            "proposer_priority": "-40958514920204"
+        },
+        {
+            "address": "CBC72D2784292744BB653558ED14C4E33D614B67",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "1mF7OEpB9A60O0e+64pICbqS/nN8VnsVfoySMEW2w1Q="
+            },
+            "voting_power": "199825725805690",
+            "proposer_priority": "426185584093185"
+        },
+        {
+            "address": "2CBA0C86B9BE7034D7BD2F02C1A5FEDFE1FAD2D8",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "eUvXue8zslf+dC4TxNBXVIzMZzf6CtwagwObU6rQxb4="
+            },
+            "voting_power": "7",
+            "proposer_priority": "-719896605342281"
+        }
+    ],
+    "count": "5",
+    "total": "5"
+}

--- a/contracts/javascore/score-util/src/main/java/ibc/icon/score/util/Proto.java
+++ b/contracts/javascore/score-util/src/main/java/ibc/icon/score/util/Proto.java
@@ -64,10 +64,18 @@ public class Proto {
     public static DecodeResponse<BigInteger> decodeVarInt(byte[] data, int index) {
         DecodeResponse<BigInteger> resp = new DecodeResponse<>();
 
-        DataSize dataSize = getDataSize(data, index);
+        long value = 0;
+        for (int shift = 0; shift < 64; shift += 7) {
+            final byte b = data[index];
+            index++;
+            value |= (long) (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                break;
+            }
+        }
 
-        resp.index = dataSize.index;
-        resp.res = BigInteger.valueOf(dataSize.length);
+        resp.index = index;
+        resp.res = BigInteger.valueOf(value);
         return resp;
     }
 


### PR DESCRIPTION
Currently we use the size decoder to decode varints, but it is limited to ints. While varints can be as large as longs. So if to large values where supplied the decoding failed

## Description

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)
- [ ] I have added version bump label on PR.

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
