### PR TITLE
feat: Allow xCall connection configurations when channel is not open

### DIFF
--- a/contracts/cosmwasm-vm/cw-common/src/xcall_connection_msg.rs
+++ b/contracts/cosmwasm-vm/cw-common/src/xcall_connection_msg.rs
@@ -26,6 +26,13 @@ pub enum ExecuteMsg {
         client_id: String,
         timeout_height: u64,
     },
+    OverrideConnection {
+        connection_id: String,
+        counterparty_port_id: String,
+        counterparty_nid: NetId,
+        client_id: String,
+        timeout_height: u64,
+    },
     ClaimFees {
         nid: NetId,
         address: String,

--- a/contracts/cosmwasm-vm/cw-ibc-core/tests/test_client.rs
+++ b/contracts/cosmwasm-vm/cw-ibc-core/tests/test_client.rs
@@ -198,7 +198,7 @@ fn create_misbehaviour_event_test() {
 }
 
 #[test]
-fn store_client_type_sucess() {
+fn store_client_type_success() {
     let mut deps = deps();
     let contract = CwIbcCoreContext::default();
     let client_type = ClientType::new("icon_client".to_string());
@@ -1169,7 +1169,7 @@ fn fails_on_storing_already_registered_client_into_registry() {
 }
 
 #[test]
-fn sucess_on_getting_client() {
+fn success_on_getting_client() {
     let mut mock_deps = deps();
     let contract = CwIbcCoreContext::default();
     let client_type = ClientType::new("new_client_type".to_string());
@@ -1290,7 +1290,7 @@ fn fails_on_getting_client_state() {
 }
 
 #[test]
-fn sucess_on_misbehaviour_validate() {
+fn success_on_misbehaviour_validate() {
     let mut deps = deps();
     let contract = CwIbcCoreContext::default();
     let info = create_mock_info("alice", "umlg", 2000);

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/ack.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/ack.rs
@@ -45,7 +45,7 @@ pub fn make_ack_fail(err: String) -> Binary {
 /// Returns:
 ///
 /// a `Result` with either an `IbcBasicResponse` or a `ContractError`.
-pub fn on_ack_sucess(_packet: CwPacket) -> Result<CwBasicResponse, ContractError> {
+pub fn on_ack_success(_packet: CwPacket) -> Result<CwBasicResponse, ContractError> {
     let attributes = vec![attr("action", "acknowledge"), attr("success", "true")];
 
     Ok(CwBasicResponse::new().add_attributes(attributes))

--- a/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/state.rs
+++ b/contracts/cosmwasm-vm/cw-xcall-ibc-connection/src/state.rs
@@ -196,6 +196,10 @@ impl<'a> CwIbcConnection<'a> {
             .save(store, nid.to_owned(), config)
             .map_err(ContractError::Std)
     }
+
+    pub fn clear_ibc_config(&self, store: &mut dyn Storage, nid: &NetId) {
+        self.ibc_config.remove(store, nid.to_owned());
+    }
     pub fn set_ibc_host(
         &self,
         store: &mut dyn Storage,

--- a/docs/adr/XCall_IBC_Connection.md
+++ b/docs/adr/XCall_IBC_Connection.md
@@ -362,19 +362,21 @@ public void transferAdmin(Address admin) {
 
 ```java
 /**
- * Configures a ibc connection so that a channel can be establised for a specigic nid
+ * Configures a ibc connection so that a channel can be established for a specific nid
 
 
  * @param connectionId The connection id of the connection/chain to open the connection to
  * @param counterpartyPortId  The allocated port name of the connection on the counterparty chain
  * @param counterpartyNid The network Id to be associated with this connection
  * @param clientId The lightClient associated with this connection
- * @param timeoutHeight The timeoutheight to be used on packets, it is recommended to use a high value similar to the trusting period of the lightclient.
+ * @param timeoutHeight The timeout height to be used on packets, it is recommended to use a high value similar to the trusting period of the lightclient.
  */
 public void configureConnection(String connectionId, String counterpartyPortId, String counterpartyNid, String clientId, BigInteger timeoutHeight) {
     onlyAdmin();
-    assert configuredNetworkIds[connectionId][counterpartyPortId] == null
-    assert channels[counterpartyNid] == null;
+    if channels[counterpartyNid] != null:
+        assert ibc.getChannel(PORT, channels[counterpartyNid]).state != OPEN
+        channels[counterpartyNid] = null
+
     configuredNetworkIds[connectionId][counterpartyPortId] = counterpartyNid
     configuredClients[connectionId] = clientId
     configuredTimeoutHeight[connectionId] = timeoutHeight
@@ -382,9 +384,28 @@ public void configureConnection(String connectionId, String counterpartyPortId, 
 ```
 
 ```java
+/**
+ * Resets a ibc connection so that a new channel can be establish for a specific nid
+
+
+ * @param connectionId The connection id of the connection/chain to open the connection to
+ * @param counterpartyPortId  The allocated port name of the connection on the counterparty chain
+ * @param counterpartyNid The network Id to be associated with this connection
+ * @param clientId The lightClient associated with this connection
+ * @param timeoutHeight The timeout height to be used on packets, it is recommended to use a high value similar to the trusting period of the lightclient.
+ */
+public void overrideConnection(String connectionId, String counterpartyPortId, String counterpartyNid, String clientId, BigInteger timeoutHeight) {
+    onlyOwner();
+    configuredNetworkIds[connectionId][counterpartyPortId] = counterpartyNid
+    configuredClients[connectionId] = clientId
+    configuredTimeoutHeight[connectionId] = timeoutHeight
+    channels[counterpartyNid] = null
+}
+
+```
+```java
 void setFee(String nid, BigInteger packetFee, BigInteger ackFee) {
     onlyAdmin();
-    //check chainn specfic limits
     sendPacketFee[nid] = packetFee
     ackFee[nid] = ackFee
 }


### PR DESCRIPTION
Admin can now reconfigure a channel while it is not opened and Owner can now reset or override a channel config

## Description

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)
- [ ] I have added version bump label on PR.

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
