### PR TITLE
fix: add reference to CI workflow to fix error

### DIFF
--- a/.github/workflows/runner-start.yml
+++ b/.github/workflows/runner-start.yml
@@ -40,7 +40,7 @@ jobs:
           repository: icon-project/ibc-relay
       - name: Start EC2 instance
         id: start
-        uses: machulav/ec2-github-runner
+        uses: machulav/ec2-github-runner@v2
         with:
           mode: start
           github-token: ${{ secrets.GH_RUNNER_PAT }}


### PR DESCRIPTION
## Description

I noticed one of the CI workflows incorrectly references `machulav/ec2-github-runner`. GitHub requires a reference to use an action, so I added the V2 tag, and this should fix CI failures.

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)
- [ ] I have added version bump label on PR.

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
